### PR TITLE
[QNEBE-363] Command application init

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,37 @@ Example:
 ```
 </details>
 
+<!--- QNE APPLICATION INIT --->
+<details closed>
+<summary><b>qne application init</b></summary>
+Initialize an existing application in the current path which is not already registered to QNE-ADK.
+This is needed for applications not created with QNE-ADK, for example when the files come from a
+repository or are directly copied to the file system.
+Two subdirectories <b>src</b> and <b>config</b> will be created when not already there.
+When application files are in the root directory, but belong to one of the subdirectories, they are moved.
+<br></br>
+
+```
+qne application init [OPTIONS] APPLICATION_NAME
+
+  ./application_name is taken as application directory
+
+Arguments:
+  APPLICATION_NAME  Name of the application  [required]
+
+Options:
+  --help    Show this message and exit.
+
+Example:
+  qne application init application_name
+```
+</details>
+
 <!--- QNE APPLICATION CREATE --->
 <details closed>
 <summary><b>qne application create</b></summary>
 Create a new application in your current directory containing all the files that are needed to write your application.
-The application directory name will be based on the value given to <b>application</b>.
+The application directory name will be based on the value given to <b>application_name</b>.
 Two subdirectories <b>src</b> and <b>config</b> will be created, along with the default files.
 <br></br>
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -108,6 +108,28 @@ For listing remote applications, the user must be logged in.
     Example:
       qne application list --remote
 
+application init
+^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+    qne application init [OPTIONS] APPLICATION_NAME
+
+Initialize an existing application in the current path which is not already registered to QNE-ADK.
+This is needed for applications not created with QNE-ADK, for example when the files come from a
+repository or are directly copied to the file system.
+Two subdirectories `src` and `config` will be created when not already there.
+When application files are in the root directory, but belong to one of the subdirectories, they are moved.
+
+    Arguments:
+      APPLICATION_NAME  Name of the application [required]
+
+    Options:
+      --help   Show this message and exit.
+
+    Example:
+      qne application init application_name
+
 application create
 ^^^^^^^^^^^^^^^^^^
 
@@ -116,7 +138,7 @@ application create
     qne application create [OPTIONS] APPLICATION_NAME ROLES...
 
 Create a new application in your current directory containing all the files that are needed to write your application.
-The application directory name will be based on the value given to `application`.
+The application directory name will be based on the value given to `application_name`.
 Two subdirectories `src` and `config` will be created, along with the default files.
 
     Arguments:

--- a/src/adk/api/local_api.py
+++ b/src/adk/api/local_api.py
@@ -320,6 +320,8 @@ class LocalApi:
         else:
             application_data = self.get_application_data(application_path)
             application_data["application"]["name"] = application_name
+            # reset remote
+            application_data["remote"] = {}
         # write manifest
         self.set_application_data(application_path, application_data)
 

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -101,6 +101,32 @@ def show_validation_messages(validation_dict: ErrorDictType) -> None:
                 typer.echo(f"{key.upper()}: {item}")
 
 
+@applications_app.command("init")
+@catch_qne_adk_exceptions
+def applications_init(
+    application_name: str = typer.Argument(..., help="Name of the application to initialize")
+) -> None:
+    """
+    Initialize an existing application in the current path which is not already registered to QNE-ADK.
+    This is needed for applications not created with QNE-ADK, for example when the files come from a
+    repository or are directly copied to the file system.
+
+    ./application_name is taken as application directory
+
+    For example: qne application init application_name
+    """
+    validate_path_name("Application", application_name)
+
+    application_exists, existing_application_path = config_manager.application_exists(application_name)
+    if application_exists:
+        raise ApplicationAlreadyExists(application_name, existing_application_path)
+
+    cwd = Path.cwd()
+    application_path = cwd / application_name
+    processor.applications_init(application_name=application_name, application_path=application_path)
+    typer.echo(f"Application '{application_name}' initialized successfully in directory '{str(application_path)}'")
+
+
 @applications_app.command("create")
 @catch_qne_adk_exceptions
 def applications_create(
@@ -110,7 +136,7 @@ def applications_create(
     """
     Create new application.
 
-    For example: qne application create my_application Alice Bob
+    For example: qne application create application_name Alice Bob
     """
 
     # Check roles
@@ -179,7 +205,7 @@ def applications_clone(
                                  new_application_name=new_application_name,
                                  new_application_path=new_application_path)
 
-    typer.echo(f"Application '{new_application_name}' cloned successfully in directory '{str(new_application_path)}'")
+    typer.echo(f"Application '{application_name}' cloned successfully in directory '{str(new_application_path)}'")
 
 
 @applications_app.command("delete")

--- a/src/adk/managers/resource_manager.py
+++ b/src/adk/managers/resource_manager.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 import os
 import tarfile
-from typing import cast, Tuple
+from typing import cast, Tuple, List
 
 from adk.api.qne_client import QneFrontendClient
-from adk.type_aliases import app_configNetworkType, ApplicationDataType, AppSourceType
+from adk.type_aliases import ApplicationDataType, AppSourceType
 
 
 class ResourceManager:
@@ -16,7 +16,7 @@ class ResourceManager:
     """
     @staticmethod
     def prepare_resources(application_data: ApplicationDataType, application_path: Path,
-                          app_config: app_configNetworkType) -> Tuple[str, str]:
+                          files_list: List[str]) -> Tuple[str, str]:
         """ The app-files needed for running the application are in the src directory. For each role a
         source file is expected and added to the tarball.
 
@@ -25,7 +25,7 @@ class ResourceManager:
         Args:
             application_data: application data from manifest.json
             application_path: path to application files (local)
-            app_config: app_config data for this application
+            files_list: list of application files for this application
 
         Returns:
             the full path to the tarball and the file name of the tarball
@@ -34,8 +34,7 @@ class ResourceManager:
         app_file_name = (application_data["remote"]["slug"] + ".tar.gz")
         app_file_path = app_src_path / app_file_name
         with tarfile.open(app_file_path, "w:gz") as tar:
-            for role in app_config["roles"]:
-                arc_name = f'app_{role.lower()}.py'
+            for arc_name in files_list:
                 file_name = app_src_path / arc_name
                 tar.add(name=file_name, arcname=arc_name, recursive=False)
         return str(app_file_path), app_file_name

--- a/src/adk/managers/roundset_manager.py
+++ b/src/adk/managers/roundset_manager.py
@@ -28,7 +28,7 @@ class RoundSetManager:
         self.__output_dir = "LAST"
         self.__fully_connected_network_generator = FullyConnectedNetworkGenerator()
         self.__input_parser = InputParser(
-            input_dir=str(experiment_path / "input"),
+            input_dir=self.__input_dir,
             network_generator=self.__fully_connected_network_generator
         )
         self.__output_converter = OutputConverter(
@@ -92,7 +92,7 @@ class RoundSetManager:
         os.makedirs(self.__input_dir)
 
     def terminate(self) -> None:
-        """Clean up everything that the InputParser/RoundsetManager has created."""
+        """Clean up everything that the InputParser/RoundSetManager has created."""
         self.__clean()
 
     def _run_application(self) -> None:

--- a/src/adk/utils.py
+++ b/src/adk/utils.py
@@ -187,12 +187,30 @@ def copy_files(source_dir: Path, destination_dir: Path, files_list: Optional[Lis
         files_list: A list of file names which need to be copied. If None, all files in directory are copied.
 
     """
-    if not files_list:
+    if files_list is None:
         files_list = os.listdir(source_dir)
     for file_name in files_list:
         full_file_name = os.path.join(source_dir, file_name)
         if os.path.isfile(full_file_name):
             shutil.copy(full_file_name, destination_dir)
+
+
+def move_files(source_dir: Path, destination_dir: Path, files_list: List[str]) -> None:
+    """
+    Move files from source directory to destination directory.
+    No sub directories are copied. Existing files will not be overwritten
+
+    Args:
+        source_dir: directory from where files need to be moved
+        destination_dir: directory where files need to be moved to
+        files_list: A list of file names which need to be moved.
+
+    """
+    for file_name in files_list:
+        full_file_name = os.path.join(source_dir, file_name)
+        dest_file_name = os.path.join(destination_dir, file_name)
+        if os.path.isfile(full_file_name) and not os.path.isfile(dest_file_name):
+            shutil.move(full_file_name, destination_dir)
 
 
 def check_python_syntax(source_file: Path) -> Tuple[bool, str]:

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -53,6 +53,28 @@ class AppValidate(unittest.TestCase):
             },
             "remote": {}
         }
+        self.mock_app_manifest_remote = {
+            "application": {
+                "name": "remote_app",
+                "description": "add description",
+                "author": "add your name",
+                "email": "add@your.email",
+                "multi_round": False
+            },
+            "remote": {
+                "application": "https://fake.url/applications/20/",
+                "application_id": 20,
+                "slug": "remote_app",
+                "app_version": {
+                    "enabled": False,
+                    "version": 1,
+                    "app_version": "https://fake.url/app-versions/49/",
+                    "app_config": "https://fake.url/app-configs/48/",
+                    "app_result": "https://fake.url/app-results/47/",
+                    "app_source": "https://fake.url/app-sources/44/"
+                }
+            }
+        }
         self.mock_app_config = {"application": [
             {
                 "title": "Qubit state of Sender",
@@ -383,7 +405,7 @@ class ApplicationValidate(AppValidate):
             mock_is_file.return_value = True
             get_default_manifest_mock.return_value = {"application": {"name": self.application},
                                                       "remote": {}}
-            get_application_data_mock.return_value = self.mock_app_manifest
+            get_application_data_mock.return_value = self.mock_app_manifest_remote
             get_application_file_names_mock.return_value = ["app_role1.py", "app_role2.py", "lib.py"]
 
             self.local_api.init_application(self.application, self.path)

--- a/src/tests/api/test_remote_api.py
+++ b/src/tests/api/test_remote_api.py
@@ -220,6 +220,7 @@ class TestRemoteApiApplication(TestRemoteApi):
     def test_upload_application_new_app_successful(self):
         application_data = self.application_data
         application_config = {"application": self.application_config, "network": self.network_config}
+        application_source = ["application_source"]
 
         self.remote_api._RemoteApi__resource_manager.prepare_resources.return_value = self.app_path, 'tarball'
         self.remote_api._RemoteApi__resource_manager.delete_resources.return_value = None
@@ -233,24 +234,28 @@ class TestRemoteApiApplication(TestRemoteApi):
             app_data_actual = self.remote_api.upload_application(self.app_path,
                                                                  application_data,
                                                                  application_config,
-                                                                 self.result)
+                                                                 self.result,
+                                                                 application_source)
 
         self.assertDictEqual(app_data_actual, self.application_data_uploaded)
 
     def test_upload_application_new_app_creation_fails(self):
         application_data = self.application_data
         application_config = {"application": self.application_config, "network": self.network_config}
+        application_source = ["application_source"]
         application_result = self.result
 
         self.remote_api._RemoteApi__qne_client.create_application.side_effect = ApiClientError("Error: creating app")
         self.assertRaises(ApiClientError, self.remote_api.upload_application, self.app_path,
                           application_data,
                           application_config,
-                          application_result)
+                          application_result,
+                          application_source)
 
     def test_upload_application_new_appversion_creation_fails(self):
         application_data = self.application_data
         application_config = {"application": self.application_config, "network": self.network_config}
+        application_source = ["application_source"]
         application_result = self.result
         application = {
             "id": 42,
@@ -268,7 +273,8 @@ class TestRemoteApiApplication(TestRemoteApi):
         self.assertRaises(ApiClientError, self.remote_api.upload_application, self.app_path,
                           application_data,
                           application_config,
-                          application_result)
+                          application_result,
+                          application_source)
 
     def test_upload_application_appversion_exists_but_not_complete_succeeds(self):
         application_data = self.application_data_uploaded
@@ -278,6 +284,7 @@ class TestRemoteApiApplication(TestRemoteApi):
         application_data["remote"]["app_version"]["app_source"] = ''
 
         application_config = {"application": self.application_config, "network": self.network_config}
+        application_source = ["application_source"]
         application_result = self.result
 
         self.remote_api._RemoteApi__resource_manager.prepare_resources.return_value = self.app_path, 'tarball'
@@ -294,7 +301,8 @@ class TestRemoteApiApplication(TestRemoteApi):
             app_data_actual = self.remote_api.upload_application(self.app_path,
                                                                  application_data,
                                                                  application_config,
-                                                                 application_result)
+                                                                 application_result,
+                                                                 application_source)
 
         self.assertDictEqual(app_data_actual, self.application_data_uploaded)
 
@@ -306,6 +314,7 @@ class TestRemoteApiApplication(TestRemoteApi):
         application_data["remote"]["app_version"]["app_source"] = ''
 
         application_config = {"application": self.application_config, "network": self.network_config}
+        application_source = ["application_source"]
         application_result = self.result
 
         self.remote_api._RemoteApi__resource_manager.prepare_resources.return_value = self.app_path, 'tarball'
@@ -322,7 +331,8 @@ class TestRemoteApiApplication(TestRemoteApi):
         self.assertRaises(ApiClientError, self.remote_api.upload_application, self.app_path,
                           application_data,
                           application_config,
-                          application_result)
+                          application_result,
+                          application_source)
 
         self.remote_api._RemoteApi__qne_client.create_app_result.side_effect = None
         self.remote_api._RemoteApi__qne_client.create_app_result.return_value = self.app_result
@@ -331,13 +341,15 @@ class TestRemoteApiApplication(TestRemoteApi):
             app_data_actual = self.remote_api.upload_application(self.app_path,
                                                                  application_data,
                                                                  application_config,
-                                                                 application_result)
+                                                                 application_result,
+                                                                 application_source)
 
         self.assertDictEqual(app_data_actual, self.application_data_uploaded)
 
     def test_upload_existing_application_appversion_new_version(self):
         application_data = self.application_data_uploaded
         application_config = {"application": self.application_config, "network": self.network_config}
+        application_source = ["application_source"]
         self.next_app_version = {
             "id": 43,
             "url": f"{self.host}app_version/43",
@@ -381,7 +393,8 @@ class TestRemoteApiApplication(TestRemoteApi):
             app_data_actual = self.remote_api.upload_application(self.app_path,
                                                                  application_data,
                                                                  application_config,
-                                                                 self.result)
+                                                                 self.result,
+                                                                 application_source)
 
         self.assertEqual(app_data_actual["remote"]["application"], f'{self.host}application/42')
         self.assertEqual(app_data_actual["remote"]["application_id"], 42)

--- a/src/tests/managers/test_resource_manager.py
+++ b/src/tests/managers/test_resource_manager.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest.mock import call, patch, MagicMock
+import unittest
+
+from adk.managers.resource_manager import ResourceManager
+
+
+class TestResourceManager(unittest.TestCase):
+    def setUp(self) -> None:
+        self.application_data = {
+            "application": {
+                "name": "test_app",
+                "description": "test_app description",
+                "author": "my name",
+                "email": "me@my.email",
+                "multi_round": False
+            },
+            "remote": {
+                "slug": "remote_app"
+            }
+        }
+        self.path = Path('dummy')
+
+    def test_prepare_resources(self):
+        tar = MagicMock()
+        with patch("adk.managers.resource_manager.tarfile.open", tar) as mock_tarfile_open:
+            resource_manager = ResourceManager()
+
+            files_list = ["app_role1.py", "app_role2.py", "lib.py"]
+            file_path, file_name = resource_manager.prepare_resources(application_data=self.application_data,
+                                                                      application_path=self.path,
+                                                                      files_list=files_list)
+
+            mock_tarfile_open.assert_called_once_with(self.path / "src" / "remote_app.tar.gz", "w:gz")
+            tarfile = tar().__enter__()
+            tar_files_calls = [call(name=self.path / "src" / "app_role1.py", arcname="app_role1.py", recursive=False),
+                               call(name=self.path / "src" / "app_role2.py", arcname="app_role2.py", recursive=False),
+                               call(name=self.path / "src" / "lib.py", arcname="lib.py", recursive=False)]
+
+            tarfile.add.assert_has_calls(tar_files_calls, any_order=True)
+            self.assertEqual(tarfile.add.call_count, 3)
+            self.assertEqual(file_path, str(self.path / "src" / "remote_app.tar.gz"))
+            self.assertEqual(file_name, "remote_app.tar.gz")


### PR DESCRIPTION
* Added qne application init to initialize an application that was copied manual or cloned from github.
* Added description to readme and in readthedocs
* Some checks are done for application init: application doesn't exist and application name is valid
* application init adds the application to the applications config and when necessary creates application structure and moves files from the root to the correct directory
* application name in manifest is set with this application name
* Instead of app_<role>.py the src-directory of an application can contain other python files that are part of the application. Thee files need to be copied when experiment is created and uploaded (part of AppSource) when application is uploaded. Added get_application_file_names method.
* Adjusted some validation to use get_application_file_names instead of role_names only
* Some minor boyscouting in docstrings and error string (changed some capitals to lower case as was done everywhere else)
* Adjusted unit tests
* Added unit tests for the new functionality
* 