### PR TITLE
[QNEBE-511] Timeout implementation for experiment run

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,16 +350,24 @@ qne experiment run [OPTIONS] [EXPERIMENT_NAME]
   When experiment_name is given ./experiment_name is taken as experiment directory.
   When experiment_name is not given, the current directory is taken as experiment
   directory.
+  Block (remote only) waits for the experiment to finish before returning (and
+  results are available). Local experiment runs are blocked by default.
+  Timeout (optional) limits the wait (in seconds) for a blocked experiment to finish.
+  In case of a local experiment, a timeout will cancel the experiment run. A remote
+  experiment is not canceled after a timeout and results can be fetched at a later
+  moment.
 
 Arguments:
   [EXPERIMENT_NAME]  Name of the experiment
 
 Options:
-  --block  Wait for the result to be returned.  [default: False]
-  --help   Show this message and exit.
+  --block    Wait for the (remote) experiment to finish.  [default: False]
+  --timeout  Limit the wait for a blocked experiment to finish (in seconds).
+             [default: no timeout]
+  --help     Show this message and exit.
 
 Example:
-  qne experiment run --block experiment_name
+  qne experiment run --block --timeout=30 experiment_name
 ```
 </details>
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -378,19 +378,26 @@ experiment run
 
 This command will parse all experiment files and run them on the NetSquid simulator.
 
-When experiment_name is given ./experiment_name is taken as experiment directory.
-When experiment_name is not given, the current directory is taken as experiment
-directory.
+  When experiment_name is given ./experiment_name is taken as experiment directory.
+  When experiment_name is not given, the current directory is taken as experiment
+  directory.
+  Block (remote only) waits for the experiment to finish before returning (and
+  results are available). Local experiment runs are blocked by default.
+  Timeout (optional) limits the wait (in seconds) for a blocked experiment to finish.
+  In case of a local experiment, a timeout will cancel the experiment run. A remote
+  experiment is not canceled after a timeout and results can be fetched at a later
+  moment.
 
     Arguments:
       [EXPERIMENT_NAME]  Name of the experiment
 
     Options:
-      --block  Wait for the result to be returned.  [default: False]
+      --block  Wait for the (remote) experiment to finish.  [default: False]
+      --timeout  Limit the wait for a blocked experiment to finish (in seconds).  [default: no timeout]
       --help   Show this message and exit.
 
     Example:
-      qne experiment run --block experiment_name
+      qne experiment run --block --timeout=30 experiment_name
 
 experiment results
 ^^^^^^^^^^^^^^^^^^

--- a/src/adk/api/local_api.py
+++ b/src/adk/api/local_api.py
@@ -1492,7 +1492,7 @@ class LocalApi:
 
         return all_subdir_deleted and experiment_dir_deleted
 
-    def run_experiment(self, experiment_path: Path) -> List[ResultType]:
+    def run_experiment(self, experiment_path: Path, timeout: Optional[int] = None) -> List[ResultType]:
         """
         An experiment is run on the backend.
         The application input files are copied for each run, they may have changed
@@ -1501,6 +1501,7 @@ class LocalApi:
 
         Args:
             experiment_path: The location of the experiment
+            timeout: Limit the wait for result
 
         Returns:
             A list containing the results of the run
@@ -1509,7 +1510,7 @@ class LocalApi:
         local_round_set: RoundSetType = {"url": "local"}
         round_set_manager = RoundSetManager(round_set=local_round_set, asset=self.get_experiment_asset(experiment_path),
                                             experiment_path=experiment_path)
-        results = round_set_manager.process()
+        results = round_set_manager.process(timeout)
         return results
 
     def __prepare_input_files(self, experiment_path: Path) -> None:

--- a/src/adk/api/remote_api.py
+++ b/src/adk/api/remote_api.py
@@ -682,7 +682,7 @@ class RemoteApi:
 
         return str(round_set["url"]), str(experiment["id"])
 
-    def get_results(self, round_set_url: str, block: bool = False, timeout: int = 30,
+    def get_results(self, round_set_url: str, block: bool = False, timeout: Optional[int] = None,
                     wait: int = 2) -> Optional[List[ResultType]]:
         """
         For a job running, get the results. When block is True, block the call for 'timeout' seconds until the result
@@ -691,7 +691,7 @@ class RemoteApi:
         Args:
             round_set_url: which holds the results and status of the run of the remote experiment
             block: When True retry for a number of seconds
-            timeout: retry for this number of seconds to get the result
+            timeout: retry for this number of seconds to get the result (None = no timeout)
             wait: number of seconds to wait between calls to api router for the results
         """
         start_time = time.time()

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -475,7 +475,8 @@ def experiments_delete(
 @catch_qne_adk_exceptions
 def experiments_run(
     experiment_name: Optional[str] = typer.Argument(None, help="Name of the experiment"),
-    block: bool = typer.Option(False, "--block", help="Wait for the result to be returned")
+    block: bool = typer.Option(False, "--block", help="Wait for the result to be returned"),
+    timeout: Optional[int] = typer.Option(None, "--timeout", help="Limit the wait for result (in seconds)")
 ) -> None:
     """
     Run an experiment.
@@ -495,7 +496,7 @@ def experiments_run(
             local = local_api.is_experiment_local(experiment_path=experiment_path)
             typer.echo(f"Experiment is sent to the {'local' if local else 'remote'} server. "
                        f"Please wait until the results are received...")
-        results = processor.experiments_run(experiment_path=experiment_path, block=block)
+        results = processor.experiments_run(experiment_path=experiment_path, block=block, timeout=timeout)
         if results is not None:
             if results and "error" in results[0]["round_result"]:
                 typer.echo("Error encountered while running the experiment")

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -475,16 +475,24 @@ def experiments_delete(
 @catch_qne_adk_exceptions
 def experiments_run(
     experiment_name: Optional[str] = typer.Argument(None, help="Name of the experiment"),
-    block: bool = typer.Option(False, "--block", help="Wait for the result to be returned"),
-    timeout: Optional[int] = typer.Option(None, "--timeout", help="Limit the wait for result (in seconds)")
+    block: bool = typer.Option(False, "--block", help="Wait for the (remote) experiment to finish"),
+    timeout: Optional[int] = typer.Option(None, "--timeout", help="Limit the wait for the experiment to finish")
 ) -> None:
     """
     Run an experiment.
 
     When experiment_name is given ./experiment_name is taken as experiment directory. When experiment_name is not
     given, the current directory is taken as experiment directory.
+    Block (remote only) waits for the experiment to finish before returning (and results are available). Local
+    experiment runs are blocked by default.
+    Timeout (optional) limits the wait (in seconds) for a blocked experiment to finish. In case of a local experiment,
+    a timeout will cancel the experiment run. A remote experiment is not canceled after a timeout and results can be
+    fetched at a later moment.
     """
     experiment_path, _ = retrieve_experiment_name_and_path(experiment_name=experiment_name)
+    local = local_api.is_experiment_local(experiment_path=experiment_path)
+    if local:
+        block = True
     # Validate the experiment before executing the run command
     validate_dict = processor.experiments_validate(experiment_path=experiment_path)
 
@@ -493,7 +501,6 @@ def experiments_run(
         typer.echo("Experiment is invalid. Please resolve the issues and then run the experiment.")
     else:
         if block:
-            local = local_api.is_experiment_local(experiment_path=experiment_path)
             typer.echo(f"Experiment is sent to the {'local' if local else 'remote'} server. "
                        f"Please wait until the results are received...")
         results = processor.experiments_run(experiment_path=experiment_path, block=block, timeout=timeout)

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -490,9 +490,6 @@ def experiments_run(
     fetched at a later moment.
     """
     experiment_path, _ = retrieve_experiment_name_and_path(experiment_name=experiment_name)
-    local = local_api.is_experiment_local(experiment_path=experiment_path)
-    if local:
-        block = True
     # Validate the experiment before executing the run command
     validate_dict = processor.experiments_validate(experiment_path=experiment_path)
 
@@ -500,6 +497,9 @@ def experiments_run(
         show_validation_messages(validate_dict)
         typer.echo("Experiment is invalid. Please resolve the issues and then run the experiment.")
     else:
+        local = local_api.is_experiment_local(experiment_path=experiment_path)
+        if local:
+            block = True
         if block:
             typer.echo(f"Experiment is sent to the {'local' if local else 'remote'} server. "
                        f"Please wait until the results are received...")

--- a/src/adk/command_processor.py
+++ b/src/adk/command_processor.py
@@ -319,7 +319,8 @@ class CommandProcessor:
         return deleted_completely_local and deleted_remote
 
     @log_function
-    def experiments_run(self, experiment_path: Path, block: bool = True) -> Optional[List[ResultType]]:
+    def experiments_run(self, experiment_path: Path, block: bool = True,
+                        timeout: Optional[int] = None) -> Optional[List[ResultType]]:
         """ Run the experiment and get the results. When running a remote experiment depending on the parameter block
         we wait for the results, otherwise None is returned (results not yet available).
         With qne experiment results a next try can be done to get the results
@@ -327,6 +328,7 @@ class CommandProcessor:
         Args:
             experiment_path: location of experiment files
             block: do we wait for the result or not
+            timeout: Limit the wait for result
 
         Returns:
             None if remote results are not yet available, otherwise True
@@ -334,13 +336,13 @@ class CommandProcessor:
         results: Optional[List[ResultType]]
         local = self.__local.is_experiment_local(experiment_path=experiment_path)
         if local:
-            results = self.__local.run_experiment(experiment_path)
+            results = self.__local.run_experiment(experiment_path, timeout)
         else:
             experiment_data = self.__local.get_experiment_data(experiment_path)
             round_set, experiment_id = self.__remote.run_experiment(experiment_data)
             self.__local.set_experiment_id(experiment_id, experiment_path)
             self.__local.set_experiment_round_set(round_set, experiment_path)
-            results = self.__remote.get_results(round_set, block)
+            results = self.__remote.get_results(round_set, block, timeout)
 
         if results is not None:
             self.__store_results(results, experiment_path)

--- a/src/adk/managers/roundset_manager.py
+++ b/src/adk/managers/roundset_manager.py
@@ -38,9 +38,12 @@ class RoundSetManager:
             instruction_converter=self.__fully_connected_network_generator
         )
 
-    def process(self) -> List[ResultType]:
+    def process(self, timeout: Optional[int] = None) -> List[ResultType]:
         """
         Process a round by running the application on simulator.
+
+        Args:
+            timeout: Limit the wait for result
 
         Returns:
             The result of the application run
@@ -54,7 +57,7 @@ class RoundSetManager:
         message: str = ""
         trace: Optional[str] = None
         try:
-            self._run_application()
+            self._run_application(timeout)
         except CalledProcessError as exc:
             exception_type = type(exc).__name__
             message = f"NetQASM returned with exit status {exc.returncode}."
@@ -95,11 +98,14 @@ class RoundSetManager:
         """Clean up everything that the InputParser/RoundSetManager has created."""
         self.__clean()
 
-    def _run_application(self) -> None:
+    def _run_application(self, timeout: Optional[int] = None) -> None:
         """Execute the subprocess that runs the application on squidasm.
 
         Squidasm reads the directory that contains both the source and configuration files for an application. This
         method will trigger a subprocess running squidasm with a prepared directory containing these files.
+
+        Args:
+            timeout: Limit the wait for result
 
         Raises:
             CalledProcessError: If the application has failed, an exception is raised.
@@ -111,5 +117,5 @@ class RoundSetManager:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             check=True,
-            timeout=60
+            timeout=timeout
         )

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -2014,7 +2014,7 @@ class ExperimentValidate(AppValidate):
             mock_filecmp_cmp.return_value = True
             get_application_config_mock.return_value = self.mock_app_config
             self.local_api.run_experiment(experiment_path)
-            process_mock.assert_called_once()
+            process_mock.assert_called_once_with(None)
             mock_filecmp_cmp.assert_called_once_with(str(application_app), str(application_exp), shallow=False)
             get_application_config_mock.assert_not_called()
             get_experiment_asset_mock.assert_called_once()
@@ -2039,8 +2039,8 @@ class ExperimentValidate(AppValidate):
             mock_path_exists.side_effect = [False, True]
             mock_filecmp_cmp.return_value = True
             get_application_config_mock.return_value = self.mock_app_config
-            self.local_api.run_experiment(experiment_path)
-            process_mock.assert_called_once()
+            self.local_api.run_experiment(experiment_path, 30)
+            process_mock.assert_called_once_with(30)
             mock_filecmp_cmp.assert_not_called()
             get_application_config_mock.assert_not_called()
             get_experiment_asset_mock.assert_called_once()
@@ -2067,7 +2067,7 @@ class ExperimentValidate(AppValidate):
             get_application_config_mock.return_value = self.mock_app_config
             self.local_api.run_experiment(experiment_path)
             get_experiment_asset_mock.assert_called_once()
-            process_mock.assert_called_once()
+            process_mock.assert_called_once_with(None)
             expected_asset_application = [{'roles': ['Sender'],
                                           'values': [{'name': 'phi', 'value': 0.0, 'scale_value': 'pi'},
                                                      {'name': 'theta', 'value': 0.0, 'scale_value': 2.0}


### PR DESCRIPTION
* Implemented timeout for local and remote experiment run
* Timeout must be explicitly set now, no default (was 60 for local run, 30 for remote run)
* timeout overrules block in remote experiments
* local experiments are blocked by default
* Add documentation to README and readthedocs
* unit tests