### PR TITLE
[QNEBE-513] Nice error when results are fetched before running exp

### DIFF
--- a/src/adk/api/local_api.py
+++ b/src/adk/api/local_api.py
@@ -1296,7 +1296,8 @@ class LocalApi:
         """
         if not self.is_experiment_local(experiment_path):
             experiment_data = self.get_experiment_data(experiment_path)
-            return cast(str, experiment_data["meta"]["round_set"])
+            if "round_set" in experiment_data["meta"]:
+                return cast(str, experiment_data["meta"]["round_set"])
         return None
 
     @staticmethod

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -1452,6 +1452,35 @@ class ExperimentValidate(AppValidate):
             validate_experiment_application_mock.assert_called_once_with(self.path, self.mock_experiment_data,
                                                                          error_dict)
 
+    def test_validate_experiment_json_non_required_values(self):
+        # test get_experiment_round_set and get_experiment_id
+        with patch.object(LocalApi, "is_experiment_local", return_value=False) as is_experiment_local_mock, \
+             patch.object(LocalApi, "get_experiment_data",
+                          return_value=self.mock_experiment_data) as get_experiment_data_mock:
+
+            return_value = self.local_api.get_experiment_id(self.path)
+            is_experiment_local_mock.assert_called_once()
+            self.assertIsNone(return_value)
+
+            is_experiment_local_mock.reset_mock()
+            return_value = self.local_api.get_experiment_round_set(self.path)
+            is_experiment_local_mock.assert_called_once()
+            self.assertIsNone(return_value)
+
+            # add data coming from experiment run
+            self.mock_experiment_data["meta"]["experiment_id"] = 3
+            self.mock_experiment_data["meta"]["round_set"] = 'fake_url'
+
+            is_experiment_local_mock.reset_mock()
+            return_value = self.local_api.get_experiment_id(self.path)
+            is_experiment_local_mock.assert_called_once()
+            self.assertEqual(return_value, '3')
+
+            is_experiment_local_mock.reset_mock()
+            return_value = self.local_api.get_experiment_round_set(self.path)
+            is_experiment_local_mock.assert_called_once()
+            self.assertEqual(return_value, 'fake_url')
+
     def test_validate_experiment_input_all_ok(self):
         with patch("adk.api.local_api.Path.is_dir") as is_dir_mock, \
              patch.object(LocalApi, "_validate_experiment_json") as validate_experiment_json_mock, \


### PR DESCRIPTION
* when asking round_set for an experiment now first check if it is present. Because it is not filled when the experiment is not run yet (same for experiment_id but there the check was already there)
* Unit test added (for both dynamic fields)