### PR TITLE
[QNEBE-622] username email and other fields

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -113,12 +113,6 @@ max-line-length=120
 # Maximum number of lines in a module
 max-module-lines=1500
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-# no-space-check=trailing-comma,dict-separator
-
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
@@ -241,14 +235,8 @@ notes=FIXME,XXX
 
 [BASIC]
 
-# Naming hint for argument names
-# argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
 # Regular expression matching correct argument names
 argument-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
-
-# Naming hint for attribute names
-# attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct attribute names
 attr-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
@@ -256,20 +244,11 @@ attr-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
 
-# Naming hint for class attribute names
-# class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
 
-# Naming hint for class names
-# class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for constant names
-# const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -277,9 +256,6 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
-
-# Naming hint for function names
-# function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
 function-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
@@ -290,21 +266,12 @@ good-names=i,j,k,ex,Run,_
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
-# Naming hint for inline iteration names
-# inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming hint for method names
-# method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct method names
 #method-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 method-rgx=(([a-z][a-z0-9_]{2,80})|(_[a-z0-9_]*))$
-
-# Naming hint for module names
-# module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -320,9 +287,6 @@ no-docstring-rgx=^_
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
 property-classes=abc.abstractproperty
-
-# Naming hint for variable names
-# variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct variable names
 variable-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$

--- a/.pylintrc
+++ b/.pylintrc
@@ -51,7 +51,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #disable=too-few-public-methods,missing-docstring
-disable=too-few-public-methods,missing-docstring,invalid-name,no-self-use,unused-private-member,unused-argument
+disable=too-few-public-methods,missing-docstring,invalid-name,unused-private-member,unused-argument
 #print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -117,7 +117,7 @@ max-module-lines=1500
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
+# no-space-check=trailing-comma,dict-separator
 
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
@@ -242,13 +242,13 @@ notes=FIXME,XXX
 [BASIC]
 
 # Naming hint for argument names
-argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+# argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct argument names
 argument-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 
 # Naming hint for attribute names
-attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+# attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct attribute names
 attr-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
@@ -257,19 +257,19 @@ attr-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 bad-names=foo,bar,baz,toto,tutu,tata
 
 # Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+# class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
 
 # Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
+# class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+# const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -279,7 +279,7 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 docstring-min-length=-1
 
 # Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+# function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
 function-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
@@ -291,20 +291,20 @@ good-names=i,j,k,ex,Run,_
 include-naming-hint=no
 
 # Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+# inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+# method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct method names
 #method-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$
 method-rgx=(([a-z][a-z0-9_]{2,80})|(_[a-z0-9_]*))$
 
 # Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+# module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -322,7 +322,7 @@ no-docstring-rgx=^_
 property-classes=abc.abstractproperty
 
 # Naming hint for variable names
-variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+# variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct variable names
 variable-rgx=(([a-z][a-z0-9_]{2,40})|(_[a-z0-9_]*))$

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ The QNE-ADK is a Quantum Network Explorer - Application Development Kit that all
 
 With the ADK you can create your own application using the ``qne application create`` command (see Commands below). An application directory is generated for you with all the necessary files for you to configure and prepare for an experiment. When configuring an application, you specify the different roles and what types of inputs your application uses. In addition, you write the functionality of your application using the NetQASM library.
 
-After creating and configuring an application, you can create an experiment for it using the ``qne experiment create`` command. Also here an experiment directory is generated with all necessary files. When configuring your experiment you can give values to the inputs that were specified when creating your application. You also choose which channels and nodes you use in your network and which role is linked to which node. A network consists of channels and each channel consists of two nodes. The nodes can communicate with each other using the channel between them.
+After creating and configuring an application, you can create an experiment for it using the ``qne experiment create`` command. An experiment directory is generated with all necessary files. When configuring your experiment you can give values to the inputs that were specified when creating your application. You also choose which channels and nodes you use in your network and which role is linked to which node. A network consists of channels and each channel consists of two nodes. The nodes can communicate with each other using the channel between them.
 
 Once your experiment is configured you are ready to run it using the ``qne experiment run`` command. Your experiment is parsed and sent to the NetSquid simulator. After some time your experiment run will be finished and a results directory will be generated in which all the results of your experiment are stored.
 
 
 ## Prerequisites
-- A modern Linux or MacOS (10 or 11) 64-bit (x86_64) operating system. If you don’t have Linux or MacOS you could run it via virtualization, e.g. using VirtualBox. If you have Windows 10 or 11 you can also use the [Bash on Ubuntu](https://docs.microsoft.com/en-us/windows/wsl/) subsystem.
+- A modern Linux or macOS (10 or 11) 64-bit (x86_64) operating system. If you don’t have Linux or macOS you could run it via virtualization, e.g. using VirtualBox. If you have Windows 10 or 11 you can also use the [Bash on Ubuntu](https://docs.microsoft.com/en-us/windows/wsl/) subsystem.
 - A [virtual environment](https://docs.python.org/3/library/venv.html) should be created and activated before creating an application.
 - Python version 3.7 or higher and pip version 19 or higher.
 - NetQASM makes use of SquidASM for which you need credentials in order to use it. These credentials can be obtained by registering on the forum of [NetSquid](https://forum.netsquid.org/).
@@ -31,7 +31,7 @@ pip install squidasm --extra-index-url=https://{netsquid-user-name}:{netsquid-pa
 Now everything should be setup and ready in order to create your own applications and experiments and run them on the simulator!
 
 ## Commands
-The QNE-ADK uses various commands to create and run your applications and experiments. All of the commands are listed below:
+The QNE-ADK uses various commands to create and run your applications and experiments. All the commands are listed below:
 
 <!--- QNE APPLICATION LIST --->
 <details closed>
@@ -401,7 +401,7 @@ Example:
 <!--- QNE LOGIN --->
 <details closed>
 <summary><b>qne login</b></summary>
-Log in to a Quantum Network Explorer.
+Log in to a Quantum Network Explorer. For backwards compatibility reasons, email can be sent as username to log in.
 <br></br>
 
 ```
@@ -413,10 +413,12 @@ Arguments:
 Options:
   --email TEXT     Email of the remote user  [required]
   --password TEXT  Password of the remote user  [required]
+  --username       Send email as username to log in [optional] [default:
+                   False]
   --help           Show this message and exit.
 
 Example:
-  qne login --email=myemail@email.com --password=my_password https://api.quantum-network.com
+  qne login --email=myemail@email.com --password=my_password --username https://api.quantum-network.com
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -411,12 +411,12 @@ Arguments:
   [HOST]  Name of the host to log in to
 
 Options:
-  --username TEXT  Username of the remote user  [required]
+  --email TEXT     Email of the remote user  [required]
   --password TEXT  Password of the remote user  [required]
   --help           Show this message and exit.
 
 Example:
-  qne login --username=my_user_name --password=my_password https://api.quantum-network.com
+  qne login --email=myemail@email.com --password=my_password https://api.quantum-network.com
 ```
 </details>
 

--- a/docs/application_configuration.rst
+++ b/docs/application_configuration.rst
@@ -47,7 +47,7 @@ The src directory consists of a number of python files. These are the actual app
 in the application a python file is created. The file names of these application files are based on the role names you
 specified while creating the application.
 
-The file ``manifest.json`` contains meta data for the application as application name, description, author etc.
+The file ``manifest.json`` contains metadata for the application as application name, description etc.
 
 To make sure that your application has all the necessary and the correct structure, you can validate it with the
 following command:
@@ -150,8 +150,8 @@ if the JSON files contain valid JSON.*
 manifest.json
 _____________
 
-The file ``manifest.json`` contains meta data for the application as application name, description, author, e-mail
-address and if the application need to run multiple times to come to an result. When the application is uploaded to
+The file ``manifest.json`` contains metadata for the application as application name, description
+and if the application need to run multiple times to come to an result. When the application is uploaded to
 Quantum Network Explorer, this file also contains remote data to be able to link the local application to the remote
 application.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -437,12 +437,12 @@ Log in to a Quantum Network Explorer.
       [HOST]  Name of the host to log in to
 
     Options:
-      --username  TEXT Username of the remote user  [required]
+      --email  TEXT Email of the remote user  [required]
       --password  TEXT Password of the remote user  [required]
       --help  Show this message and exit.
 
     Example:
-      qne login --username=my_user_name --password=my_password https://api.quantum-network.com
+      qne login --email=myemail@email.com --password=my_password https://api.quantum-network.com
 
 logout
 ^^^^^^

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -10,7 +10,7 @@ experiment. When configuring an application, you specify the different roles and
 application uses. In addition, you write the functionality of your application using the NetQASM library.
 
 After creating and configuring an application, you can create an experiment for it using the ``qne experiment create``
-command. Also here an experiment directory is generated with all necessary files. When configuring your experiment
+command. An experiment directory is generated with all necessary files. When configuring your experiment
 you can give values to the inputs that were specified when creating your application. You also choose which channels
 and nodes you use in your network and which role is linked to which node. A network consists of channels and each
 channel consists of two nodes. The nodes can communicate with each other using the channel between them.
@@ -22,7 +22,7 @@ directory will be generated in which all the results of your experiment are stor
 
 Prerequisites
 -------------
-* A modern Linux or MacOS (10 or 11) 64-bit (x86_64) operating system. If you don't have Linux or MacOS you could run
+* A modern Linux or macOS (10 or 11) 64-bit (x86_64) operating system. If you don't have Linux or macOS you could run
   it via virtualization, e.g. using VirtualBox. If you have Windows 10 or 11 you can also use
   the `Bash on Ubuntu <https://docs.microsoft.com/en-us/windows/wsl/>`_ subsystem.
 * A `virtual environment <https://docs.python.org/3/library/venv.html>`_ should be created and activated before
@@ -87,7 +87,7 @@ The documentation is then build in 'docs/_build/html' and can be viewed `here <i
 
 Commands
 --------
-The QNE-ADK uses various commands to create and run your applications and experiments. All of the commands are
+The QNE-ADK uses various commands to create and run your applications and experiments. All the commands are
 listed below:
 
 application list
@@ -105,8 +105,11 @@ For listing remote applications, the user must be logged in.
       --local   List local applications  [default: False].
       --help   Show this message and exit.
 
-    Example:
-      qne application list --remote
+Example:
+
+.. code-block:: console
+
+    qne application list --remote
 
 application init
 ^^^^^^^^^^^^^^^^
@@ -127,8 +130,11 @@ When application files are in the root directory, but belong to one of the subdi
     Options:
       --help   Show this message and exit.
 
-    Example:
-      qne application init application_name
+Example:
+
+.. code-block:: console
+
+    qne application init application_name
 
 application create
 ^^^^^^^^^^^^^^^^^^
@@ -149,8 +155,11 @@ Two subdirectories `src` and `config` will be created, along with the default fi
     Options:
       --help  Show this message and exit.
 
-    Example:
-      qne application create my_application Alice Bob
+Example:
+
+.. code-block:: console
+
+    qne application create my_application Alice Bob
 
 application clone
 ^^^^^^^^^^^^^^^^^
@@ -175,8 +184,11 @@ author.
       --remote  Clone remote application  [default: False]
       --help  Show this message and exit.
 
-    Example:
-      qne application clone existing_application new_application
+Example:
+
+.. code-block:: console
+
+    qne application clone existing_application new_application
 
 application delete
 ^^^^^^^^^^^^^^^^^^
@@ -201,8 +213,11 @@ application directory.
     Options:
       --help  Show this message and exit.
 
-    Example:
-      qne application delete application_name
+Example:
+
+.. code-block:: console
+
+    qne application delete application_name
 
 application validate
 ^^^^^^^^^^^^^^^^^^^^
@@ -222,8 +237,11 @@ application directory.
     Options:
       --help  Show this message and exit.
 
-    Example:
-      qne application validate
+Example:
+
+.. code-block:: console
+
+    qne application validate
 
 application upload
 ^^^^^^^^^^^^^^^^^^
@@ -247,8 +265,11 @@ application directory.
     Options:
       --help   Show this message and exit.
 
-    Example:
-      qne application upload application_name
+Example:
+
+.. code-block:: console
+
+    qne application upload application_name
 
 application publish
 ^^^^^^^^^^^^^^^^^^^
@@ -275,8 +296,11 @@ application directory.
     Options:
       --help   Show this message and exit.
 
-    Example:
-      qne application publish application_name
+Example:
+
+.. code-block:: console
+
+    qne application publish application_name
 
 experiment list
 ^^^^^^^^^^^^^^^
@@ -291,8 +315,11 @@ For listing remote experiments, the user must be logged in.
     Options:
       --help   Show this message and exit.
 
-    Example:
-      qne experiment list
+Example:
+
+.. code-block:: console
+
+    qne experiment list
 
 experiment create
 ^^^^^^^^^^^^^^^^^
@@ -315,8 +342,11 @@ When the experiment is created for a remote application the user must be logged 
       --remote  Use remote application configuration [default: False]
       --help   Show this message and exit.
 
-    Example:
-      qne experiment create experiment_name application_name europe
+Example:
+
+.. code-block:: console
+
+    qne experiment create experiment_name application_name europe
 
 experiment delete
 ^^^^^^^^^^^^^^^^^
@@ -344,8 +374,11 @@ delete. No local files are deleted.
       --remote  Delete a remote experiment  [default: False]
       --help  Show this message and exit.
 
-    Example:
-      qne experiment delete experiment_name
+Example:
+
+.. code-block:: console
+
+    qne experiment delete experiment_name
 
 experiment validate
 ^^^^^^^^^^^^^^^^^^^
@@ -366,8 +399,11 @@ directory.
     Options:
       --help  Show this message and exit.
 
-    Example:
-      qne experiment validate experiment_name
+Example:
+
+.. code-block:: console
+
+    qne experiment validate experiment_name
 
 experiment run
 ^^^^^^^^^^^^^^
@@ -396,8 +432,11 @@ This command will parse all experiment files and run them on the NetSquid simula
       --timeout  Limit the wait for a blocked experiment to finish (in seconds).  [default: no timeout]
       --help   Show this message and exit.
 
-    Example:
-      qne experiment run --block --timeout=30 experiment_name
+Example:
+
+.. code-block:: console
+
+    qne experiment run --block --timeout=30 experiment_name
 
 experiment results
 ^^^^^^^^^^^^^^^^^^
@@ -421,8 +460,11 @@ directory.
               False]
       --help  Show this message and exit.
 
-    Example:
-      qne experiment results experiment_name
+Example:
+
+.. code-block:: console
+
+    qne experiment results experiment_name
 
 login
 ^^^^^
@@ -431,7 +473,7 @@ login
 
     qne login [OPTIONS] [HOST]
 
-Log in to a Quantum Network Explorer.
+Log in to a Quantum Network Explorer. For backwards compatibility reasons, email can be sent as username to log in.
 
     Arguments:
       [HOST]  Name of the host to log in to
@@ -439,10 +481,15 @@ Log in to a Quantum Network Explorer.
     Options:
       --email  TEXT Email of the remote user  [required]
       --password  TEXT Password of the remote user  [required]
+      --username  Send email as username to log in [optional] [default:
+                  False]
       --help  Show this message and exit.
 
-    Example:
-      qne login --email=myemail@email.com --password=my_password https://api.quantum-network.com
+Example:
+
+.. code-block:: console
+
+    qne login --email=myemail@email.com --password=my_password --username https://api.quantum-network.com
 
 logout
 ^^^^^^
@@ -459,8 +506,11 @@ Log out from Quantum Network Explorer.
     Options:
       --help  Show this message and exit.
 
-    Example:
-      qne logout https://api.quantum-network.com
+Example:
+
+.. code-block:: console
+
+    qne logout https://api.quantum-network.com
 
 network list
 ^^^^^^^^^^^^
@@ -476,8 +526,11 @@ List available networks. For listing remote networks, the user must be logged in
       --local   List local networks  [default: True]
       --help  Show this message and exit.
 
-    Example:
-      qne network list --remote
+Example:
+
+.. code-block:: console
+
+    qne network list --remote
 
 network update
 ^^^^^^^^^^^^^^
@@ -493,8 +546,11 @@ For updating local networks, the user must be logged in.
       --overwrite  Overwrite local networks  [default: False]
       --help  Show this message and exit.
 
-    Example:
-      qne network update --overwrite
+Example:
+
+.. code-block:: console
+
+    qne network update --overwrite
 
 More documentation
 ------------------

--- a/docs/json_examples/application_manifest_example.json
+++ b/docs/json_examples/application_manifest_example.json
@@ -2,8 +2,6 @@
   "application": {
     "name": "teleport",
     "description": "The description of the teleport application",
-    "author": "Your name",
-    "email": "your.email@address.here",
     "multi_round": false
   },
   "remote": {

--- a/docs/json_examples/application_manifest_layout.json
+++ b/docs/json_examples/application_manifest_layout.json
@@ -2,8 +2,6 @@
   "application": {
     "name": "app_name",
     "description": "add description",
-    "author": "developer name",
-    "email": "here@your.email",
     "multi_round": false
   },
   "remote": {

--- a/docs/uml/class_diagram.plantuml
+++ b/docs/uml/class_diagram.plantuml
@@ -7,7 +7,7 @@ skinparam backgroundcolor transparent
 class CommandList {
     + app: Typer
     + processor: CommandProcessor
-    + login(host:str, username: str, password: str)
+    + login(host:str, email: str, password: str)
     + logout(host: str)
     + applications_create(application: str, roles: str[])
     + applications_init()
@@ -28,7 +28,7 @@ class CommandList {
 class CommandProcessor {
     - remote: RemoteApi
     - local: LocalApi
-    + login(host:str, username: str, password: str)
+    + login(host:str, email: str, password: str)
     + logout(host: str)
     + applications_create(application: str, roles: str[], path: str)
     + applications_init(path: str)
@@ -62,7 +62,7 @@ class AuthManager {
     - login_function: Callable
     - fallback_function: Callable
     + __init__(config_dir, login_function, fallback_function)
-    + login(username: str, password: str, host: str) -> None
+    + login(email: str, password: str, host: str) -> None
     + load_token() -> str
     - store_token(token: str) -> None
     - fetch_token(function: Callable, payload: Dict[str, Any]) -> str
@@ -93,8 +93,8 @@ class LocalApi {
 class RemoteApi {
     - config_manager: ConfigManager
     + __init__(config_manager: ConfigManager) -> None
-    + login(username: str, password: str, host: str) -> None
-    # login_user(username: str, password: str, host: str) -> str
+    + login(email: str, password: str, host: str) -> None
+    # login_user(email: str, password: str, host: str) -> str
     # login_anonymous() -> str
     + logout() -> None
     + list_applications() -> ApplicationType[]

--- a/docs/uml/sequence_diagram.plantuml
+++ b/docs/uml/sequence_diagram.plantuml
@@ -12,11 +12,11 @@ participant AuthManager
 participant RoundSetManager
 participant OutputConverter
 
-CommandList -> CommandProcessor : login(host, username, password)
-    CommandProcessor -> RemoteApi : login(username, password, host)
+CommandList -> CommandProcessor : login(host, email, password)
+    CommandProcessor -> RemoteApi : login(email, password, host)
         RemoteApi -> AuthManager : __init__(config_dir, login_function, anonymous_function)
         return auth_manager
-        RemoteApi -> AuthManager : login(username, password, host)
+        RemoteApi -> AuthManager : login(email, password, host)
             AuthManager -> AuthManager : fetch_token(payload)
             return token
             AuthManager -> AuthManager : store_token(token)
@@ -357,8 +357,8 @@ CommandList -> CommandProcessor : experiments_delete(name, application, local)
             end
         return token
         RemoteApi -> RemoteApi : action('delete_experiment')
-        return 
-    return 
+        return
+    return
     CommandProcessor -> LocalApi : delete_experiment(path)
     return
 return

--- a/src/adk/api/qne_client.py
+++ b/src/adk/api/qne_client.py
@@ -56,7 +56,7 @@ class QneClient:
     def __init__(self, auth_manager: AuthManager) -> None:
         self.__auth_manager = auth_manager
         self.__base_uri = self.__auth_manager.get_active_host()
-        self.__username: Optional[str] = self.__auth_manager.get_username(self.__base_uri)
+        self.__email: Optional[str] = self.__auth_manager.get_email(self.__base_uri)
         self.__password: Optional[str] = self.__auth_manager.get_password(self.__base_uri)
         self.__refresh_token: Optional[str] = self.__auth_manager.load_token(self.__base_uri)
 
@@ -114,10 +114,10 @@ class QneClient:
             jwt_url = urljoin(jwt_url, 'refresh/')
             payload = {'refresh': self.__refresh_token}
         else:
-            assert self.__username is not None
+            assert self.__email is not None
             assert self.__password is not None
             payload = {
-                'username': self.__username,
+                'email': self.__email,
                 'password': self.__password
             }
 
@@ -137,10 +137,10 @@ class QneClient:
         auth_mech = TokenAuthentication(access_token, scheme="JWT")
         self._set_open_api_client(auth_mech)
 
-    def login(self, username: str, password: str, host: str) -> str:
+    def login(self, email: str, password: str, host: str) -> str:
         self.__refresh_token = None
         self.__base_uri = host
-        self.__username = username
+        self.__email = email
         self.__password = password
 
         self._authenticate()
@@ -150,12 +150,12 @@ class QneClient:
     def logout(self, host: str) -> None:
         self.__client = None
         self.__base_uri = self.__auth_manager.get_active_host()
-        self.__username = None
+        self.__email = None
         self.__password = None
 
     def is_logged_in(self) -> bool:
         if self.__client is None:
-            if self.__username is None or self.__password is None:
+            if self.__email is None or self.__password is None:
                 return False
         return True
 
@@ -175,7 +175,7 @@ class QneClient:
 
     def _action(self, operation_id: ActionsType, **params: ParametersType) -> Any:
         if self.__client is None:
-            if self.__username is not None and self.__password is not None:
+            if self.__email is not None and self.__password is not None:
                 self._authenticate()
             else:
                 raise NotLoggedIn()
@@ -217,8 +217,8 @@ class QneClient:
         return self.__base_uri
 
     @property
-    def username(self) -> Optional[str]:
-        return self.__username
+    def email(self) -> Optional[str]:
+        return self.__email
 
     @property
     def password(self) -> Optional[str]:
@@ -343,7 +343,7 @@ class QneFrontendClient(QneClient):  # pylint: disable-msg=R0904
         the file that has to be uploaded.
         """
         app_source_url = urljoin(self.base_uri, 'app-sources/')
-        auth = HTTPBasicAuth(self.username, self.password)
+        auth = HTTPBasicAuth(self.email, self.password)
         response = self._client_post(url=app_source_url, files=app_source_files, auth=auth)
         return cast(AppSourceType, response.json())
 

--- a/src/adk/api/qne_client.py
+++ b/src/adk/api/qne_client.py
@@ -58,6 +58,7 @@ class QneClient:
         self.__base_uri = self.__auth_manager.get_active_host()
         self.__email: Optional[str] = self.__auth_manager.get_email(self.__base_uri)
         self.__password: Optional[str] = self.__auth_manager.get_password(self.__base_uri)
+        self.__use_username: Optional[bool] = self.__auth_manager.get_use_username(self.__base_uri)
         self.__refresh_token: Optional[str] = self.__auth_manager.load_token(self.__base_uri)
 
         self._headers: Dict[str, str] = {}
@@ -116,10 +117,16 @@ class QneClient:
         else:
             assert self.__email is not None
             assert self.__password is not None
-            payload = {
-                'email': self.__email,
-                'password': self.__password
-            }
+            if self.__use_username:
+                payload = {
+                    'username': self.__email,
+                    'password': self.__password
+                }
+            else:
+                payload = {
+                    'email': self.__email,
+                    'password': self.__password
+                }
 
         response = self._client_post(jwt_url, data=payload).json()
         self.__refresh_token = response.get("refresh", self.__refresh_token)
@@ -137,11 +144,12 @@ class QneClient:
         auth_mech = TokenAuthentication(access_token, scheme="JWT")
         self._set_open_api_client(auth_mech)
 
-    def login(self, email: str, password: str, host: str) -> str:
+    def login(self, email: str, password: str, host: str, use_username: bool) -> str:
         self.__refresh_token = None
         self.__base_uri = host
         self.__email = email
         self.__password = password
+        self.__use_username = use_username
 
         self._authenticate()
         assert self.__refresh_token is not None
@@ -152,6 +160,7 @@ class QneClient:
         self.__base_uri = self.__auth_manager.get_active_host()
         self.__email = None
         self.__password = None
+        self.__use_username = None
 
     def is_logged_in(self) -> bool:
         if self.__client is None:
@@ -301,9 +310,7 @@ class QneFrontendClient(QneClient):  # pylint: disable-msg=R0904
     def partial_update_application(self, application_id: str, application: ApplicationType) -> ApplicationType:
         params = self._cast_parameter_type({
             'name': application['name'],
-            'description': application['description'],
-            'author': application['author'],
-            'email': application['email']
+            'description': application['description']
         })
         response = self._action('partialUpdateApplication', id=application_id, application=params)
         return cast(ApplicationType, response)

--- a/src/adk/api/qne_client.py
+++ b/src/adk/api/qne_client.py
@@ -161,14 +161,14 @@ class QneClient:
 
     @staticmethod
     def _client_get(url: str, **params: ParametersType) -> Any:
-        result = requests.get(url, **params)  # type: ignore
+        result = requests.get(url, timeout=10, **params)  # type: ignore
         if isinstance(result, Response):
             result.raise_for_status()
         return result
 
     @staticmethod
     def _client_post(url: str, **params: ParametersType) -> Any:
-        result = requests.post(url, **params)  # type: ignore
+        result = requests.post(url, timeout=10, **params)  # type: ignore
         if isinstance(result, Response):
             result.raise_for_status()
         return result

--- a/src/adk/api/remote_api.py
+++ b/src/adk/api/remote_api.py
@@ -52,29 +52,29 @@ class RemoteApi:
 
         self.__qne_client = QneFrontendClient(self.auth_manager)
         self.__base_uri = self.auth_manager.get_active_host()
-        self.__username: Optional[str] = self.auth_manager.get_username(self.__base_uri)
+        self.__email: Optional[str] = self.auth_manager.get_email(self.__base_uri)
         self.__password: Optional[str] = self.auth_manager.get_password(self.__base_uri)
         self.__refresh_token: Optional[str] = self.auth_manager.load_token(self.__base_uri)
 
         self.__resource_manager = ResourceManager()
 
-    def __login_user(self, username: str, password: str, host: str) -> str:
+    def __login_user(self, email: str, password: str, host: str) -> str:
         self.__refresh_token = None
         self.__base_uri = host
-        self.__username = username
+        self.__email = email
         self.__password = password
 
-        self.__refresh_token = self.__qne_client.login(username, password, host)
+        self.__refresh_token = self.__qne_client.login(email, password, host)
         return self.__refresh_token
 
     def __login_anonymous(self) -> str:
         pass
 
-    def login(self, username: str, password: str, host: str) -> None:
+    def login(self, email: str, password: str, host: str) -> None:
         """
-        Login the user on host (uri) based upon the username/password values given
+        Login the user on host (uri) based upon the email/password values given
         """
-        self.auth_manager.login(username, password, host)
+        self.auth_manager.login(email, password, host)
 
     def __logout_user(self, host: str) -> None:
         self.__qne_client.logout(host)

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -43,7 +43,7 @@ logging.basicConfig(level=logging.INFO)
 @catch_qne_adk_exceptions
 def login(
     host: str = typer.Argument(None),
-    username: str = typer.Option(..., prompt=True, help="Username of the remote user"),
+    email: str = typer.Option(..., prompt=True, help="Email of the remote user"),
     password: str = typer.Option(
         ..., prompt=True, hide_input=True, help="Password of the remote user"
     ),
@@ -51,9 +51,9 @@ def login(
     """
     Log in to a Quantum Network Explorer
     """
-    processor.login(host=host, username=username, password=password)
+    processor.login(host=host, email=email, password=password)
     host = remote_api.get_active_host()
-    typer.echo(f"Log in to '{host}' as user '{username}' succeeded")
+    typer.echo(f"Log in to '{host}' as user '{email}' succeeded")
 
 
 @app.command("logout")

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -44,14 +44,13 @@ logging.basicConfig(level=logging.INFO)
 def login(
     host: str = typer.Argument(None),
     email: str = typer.Option(..., prompt=True, help="Email of the remote user"),
-    password: str = typer.Option(
-        ..., prompt=True, hide_input=True, help="Password of the remote user"
-    ),
+    password: str = typer.Option(..., prompt=True, hide_input=True, help="Password of the remote user"),
+    username: Optional[bool] = typer.Option(False, "--username", help="Email is sent as username to login"),
 ) -> None:
     """
     Log in to a Quantum Network Explorer
     """
-    processor.login(host=host, email=email, password=password)
+    processor.login(host=host, email=email, password=password, use_username=username)
     host = remote_api.get_active_host()
     typer.echo(f"Log in to '{host}' as user '{email}' succeeded")
 

--- a/src/adk/command_processor.py
+++ b/src/adk/command_processor.py
@@ -25,7 +25,7 @@ class CommandProcessor:
         self.__local = local_api
 
     @log_function
-    def login(self, host: str, email: str, password: str) -> None:
+    def login(self, host: str, email: str, password: str, use_username: bool) -> None:
         """
         Redirects login to remote api.
 
@@ -33,9 +33,10 @@ class CommandProcessor:
             host: host to log on to
             email: the user's email
             password: the password
+            use_username: use username field to log in instead of email
 
         """
-        self.__remote.login(email=email, password=password, host=host)
+        self.__remote.login(email=email, password=password, host=host, use_username=use_username)
 
     @log_function
     def logout(self, host: Optional[str]) -> bool:

--- a/src/adk/command_processor.py
+++ b/src/adk/command_processor.py
@@ -25,17 +25,17 @@ class CommandProcessor:
         self.__local = local_api
 
     @log_function
-    def login(self, host: str, username: str, password: str) -> None:
+    def login(self, host: str, email: str, password: str) -> None:
         """
         Redirects login to remote api.
 
         Args:
             host: host to log on to
-            username: the user
+            email: the user's email
             password: the password
 
         """
-        self.__remote.login(username=username, password=password, host=host)
+        self.__remote.login(email=email, password=password, host=host)
 
     @log_function
     def logout(self, host: Optional[str]) -> bool:

--- a/src/adk/managers/auth_manager.py
+++ b/src/adk/managers/auth_manager.py
@@ -27,26 +27,26 @@ class AuthManager:
         self.__logout_function = logout_function
         self.__active_host = self.__read_active_host()
 
-    def login(self, username: Optional[str], password: Optional[str], host: Optional[str]) -> None:
+    def login(self, email: Optional[str], password: Optional[str], host: Optional[str]) -> None:
         """
         When a token is not found it tries to login
         with basic authentication read from the environment variables QNE_EMAIL and QNE_PASSWORD. When the environment
         variables are not both set, email and password are read from standard input.
 
-        :param username: username (e-mail)
+        :param email: e-mail
         :param password: password
         :param host: the Quantum Network host for which we try to log in
 
         """
         if host is None:
             host = QNE_URL
-        if username is not None and password is not None and host is not None:
+        if email is not None and password is not None and host is not None:
             token = self.__fetch_token(self.__login_function,
-                                       {'username': username, 'password': password, 'host': host})
+                                       {'email': email, 'password': password, 'host': host})
         else:
             token = self.__fetch_token(self.__fallback_function, {'host': host})
 
-        self.__store_token(host, token, username, password)
+        self.__store_token(host, token, email, password)
         self.__set_active_host(host)
 
     def logout(self, host: Optional[str]) -> None:
@@ -82,14 +82,14 @@ class AuthManager:
         """
         return self.__get_item_from_host(host, "token")
 
-    def __store_token(self, host: str, token: str, username: Optional[str], password: Optional[str]) -> None:
+    def __store_token(self, host: str, token: str, email: Optional[str], password: Optional[str]) -> None:
         """Save the token for a host to a file. Currently allowing one login at a time.
 
         :param host: the Quantum Network host for which the token is saved.
         :param token: the Quantum Network token to save.
         """
         accounts = {}
-        accounts[host] = {"token": token, "username": username, "password": password}
+        accounts[host] = {"token": token, "email": email, "password": password}
         write_json_file(self.auth_config, accounts)
 
     def set_token(self, host: str, token: str) -> None:
@@ -143,11 +143,11 @@ class AuthManager:
         accounts: AuthType = read_json_file(self.auth_config)
 
         if host in accounts:
-            return accounts[host][item]
+            return accounts[host].get(item)
         return None
 
     def get_password(self, host: str) -> Optional[str]:
         return self.__get_item_from_host(host, "password")
 
-    def get_username(self, host: str) -> Optional[str]:
-        return self.__get_item_from_host(host, "username")
+    def get_email(self, host: str) -> Optional[str]:
+        return self.__get_item_from_host(host, "email")

--- a/src/adk/managers/auth_manager.py
+++ b/src/adk/managers/auth_manager.py
@@ -1,6 +1,6 @@
 import os.path
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from adk.exceptions import DirectoryIsFile
 from adk.type_aliases import (AuthType, FallbackFunctionType, LoginFunctionType, LogoutFunctionType,
@@ -83,7 +83,7 @@ class AuthManager:
         :return:
             The Quantum Network token for this host or None when no token is found or token is empty.
         """
-        return self.__get_item_from_host(host, "token")
+        return str(self.__get_item_from_host(host, "token"))
 
     def __store_token(self, host: str, token: str, email: Optional[str], password: Optional[str],
                       use_username: Optional[bool]) -> None:
@@ -97,7 +97,7 @@ class AuthManager:
         """
         accounts = {}
         accounts[host] = {"token": token, "email": email, "password": password,
-                          "use_username": None if use_username is None else '1' if use_username else '0'}
+                          "use_username": None if use_username is None else use_username}
         write_json_file(self.auth_config, accounts)
 
     def set_token(self, host: str, token: str) -> None:
@@ -147,7 +147,7 @@ class AuthManager:
         """Get the active host"""
         return self.__active_host
 
-    def __get_item_from_host(self, host: str, item: str) -> Optional[str]:
+    def __get_item_from_host(self, host: str, item: str) -> Optional[Union[str, bool]]:
         accounts: AuthType = read_json_file(self.auth_config)
 
         if host in accounts:
@@ -155,11 +155,11 @@ class AuthManager:
         return None
 
     def get_password(self, host: str) -> Optional[str]:
-        return self.__get_item_from_host(host, "password")
+        return str(self.__get_item_from_host(host, "password"))
 
     def get_email(self, host: str) -> Optional[str]:
-        return self.__get_item_from_host(host, "email")
+        return str(self.__get_item_from_host(host, "email"))
 
     def get_use_username(self, host: str) -> Optional[bool]:
-        use_username = self.__get_item_from_host(host, "use_username")
-        return None if use_username is None else use_username == '1'
+        use_username = bool(self.__get_item_from_host(host, "use_username"))
+        return None if use_username is None else use_username

--- a/src/adk/managers/auth_manager.py
+++ b/src/adk/managers/auth_manager.py
@@ -67,7 +67,7 @@ class AuthManager:
         :return:
             The Quantum Network token or None when no token is found.
         """
-        token = self.__read_token(host)
+        token = self.get_token(host)
         # if token is None:
         #     token = self.__fetch_token(self.__fallback_function, {'host': host})
         return token
@@ -75,15 +75,6 @@ class AuthManager:
     def __create_config(self) -> None:
         """ Creates the authorization config file in the .qne/ root directory"""
         write_json_file(self.auth_config, {})
-
-    def __read_token(self, host: str) -> Optional[str]:
-        """ Try to read an earlier stored Quantum Network token from file for a certain host.
-
-        :param host: the Quantum Network host.
-        :return:
-            The Quantum Network token for this host or None when no token is found or token is empty.
-        """
-        return str(self.__get_item_from_host(host, "token"))
 
     def __store_token(self, host: str, token: str, email: Optional[str], password: Optional[str],
                       use_username: Optional[bool]) -> None:
@@ -154,12 +145,42 @@ class AuthManager:
             return accounts[host].get(item)
         return None
 
-    def get_password(self, host: str) -> Optional[str]:
-        return str(self.__get_item_from_host(host, "password"))
-
     def get_email(self, host: str) -> Optional[str]:
-        return str(self.__get_item_from_host(host, "email"))
+        """ Try to read an earlier stored email from file for a certain host.
+
+        :param host: the Quantum Network host.
+        :return:
+            The stored email for this user or None when no email is found
+        """
+        email = self.__get_item_from_host(host, "email")
+        return None if email is None else str(email)
+
+    def get_password(self, host: str) -> Optional[str]:
+        """ Try to read an earlier stored password from file for a certain host.
+
+        :param host: the Quantum Network host.
+        :return:
+            The stored password for this user or None when no password is found
+        """
+        password = self.__get_item_from_host(host, "password")
+        return None if password is None else str(password)
+
+    def get_token(self, host: str) -> Optional[str]:
+        """ Try to read an earlier stored Quantum Network token from file for a certain host.
+
+        :param host: the Quantum Network host.
+        :return:
+            The Quantum Network token for this host or None when no token is found or token is empty.
+        """
+        token = self.__get_item_from_host(host, "token")
+        return None if token is None else str(token)
 
     def get_use_username(self, host: str) -> Optional[bool]:
-        use_username = bool(self.__get_item_from_host(host, "use_username"))
-        return None if use_username is None else use_username
+        """ Try to read an earlier stored flag for using username or email to log in from file for a certain host.
+
+        :param host: the Quantum Network host.
+        :return:
+            The stored flag for using email or username to log in for this user or None when no flag is found
+        """
+        use_username = self.__get_item_from_host(host, "use_username")
+        return None if use_username is None else bool(use_username)

--- a/src/adk/managers/auth_manager.py
+++ b/src/adk/managers/auth_manager.py
@@ -162,4 +162,4 @@ class AuthManager:
 
     def get_use_username(self, host: str) -> Optional[bool]:
         use_username = self.__get_item_from_host(host, "use_username")
-        return None if use_username is None else True if use_username == '1' else False
+        return None if use_username is None else use_username == '1'

--- a/src/adk/schema/applications/manifest.json
+++ b/src/adk/schema/applications/manifest.json
@@ -16,15 +16,6 @@
           "type": "string",
           "maxLength": 512
         },
-        "author": {
-          "type": "string",
-          "maxLength": 64
-        },
-        "email": {
-          "type": "string",
-          "format": "email",
-          "maxLength": 254
-        },
         "multi_round": {
           "type": "boolean"
         }
@@ -32,8 +23,6 @@
       "required": [
         "name",
         "description",
-        "author",
-        "email",
         "multi_round"
       ],
       "additionalProperties": false

--- a/src/adk/type_aliases.py
+++ b/src/adk/type_aliases.py
@@ -68,7 +68,7 @@ GenericNetworkData = Dict[str, Any]
 
 AuthType = Dict[str, Dict[str, str]]
 
-LoginFunctionType = Callable[[str, str, str], str]
+LoginFunctionType = Callable[[str, str, str, bool], str]
 LogoutFunctionType = Callable[[str], None]
 FallbackFunctionType = Callable[[], str]
 TokenFetchFunctionType = Union[LoginFunctionType, FallbackFunctionType]

--- a/src/adk/utils.py
+++ b/src/adk/utils.py
@@ -158,10 +158,10 @@ def get_py_dummy() -> str:
 
 
 def get_default_manifest(application_name: str) -> Dict[str, Dict[str, Any]]:
+    """ Default (minimal) manifest structure is returned, that can be used for a (local) application.
+    """
     default_manifest: Dict[str, Dict[str, Any]] = {"application": {"name": f"{application_name}",
                                                                    "description": "add description",
-                                                                   "author": "add your name",
-                                                                   "email": "add@your.email",
                                                                    "multi_round": False},
                                                    "remote": {}}
     return default_manifest
@@ -179,7 +179,7 @@ def validate_path_name(obj: str, name: str) -> None:
 def copy_files(source_dir: Path, destination_dir: Path, files_list: Optional[List[str]] = None) -> None:
     """
     Copy all the files from source directory to destination directory.
-    No sub directories are copied.
+    No subdirectories are copied.
 
     Args:
         source_dir: directory from where files need to be copied
@@ -198,7 +198,7 @@ def copy_files(source_dir: Path, destination_dir: Path, files_list: Optional[Lis
 def move_files(source_dir: Path, destination_dir: Path, files_list: List[str]) -> None:
     """
     Move files from source directory to destination directory.
-    No sub directories are copied. Existing files will not be overwritten
+    No subdirectories are copied. Existing files will not be overwritten
 
     Args:
         source_dir: directory from where files need to be moved

--- a/src/adk/validators.py
+++ b/src/adk/validators.py
@@ -2,7 +2,7 @@ import platform
 import os
 from pathlib import Path
 from typing import Tuple, Any
-from jsonschema import Draft7Validator, RefResolver, draft7_format_checker
+from jsonschema import Draft7Validator, RefResolver
 from jsonschema.exceptions import ValidationError
 
 from adk.exceptions import JsonFileNotFound, MalformedJsonFile, PackageNotComplete
@@ -62,7 +62,7 @@ def validate_json_schema(file_name: Path, schema_path: Path) -> Tuple[bool, Any]
         else:
             json_schema_full_path = os.path.realpath(schema_path)
             resolver = RefResolver(base_uri=f'file://{json_schema_full_path}', referrer=json_schema)
-        Draft7Validator(json_schema, resolver=resolver, format_checker=draft7_format_checker).validate(json_file)
+        Draft7Validator(json_schema, resolver=resolver).validate(json_file)
         return True, None
     except ValidationError as ve:
         return False, f'In file {file_name}: {ve.message}'

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -47,8 +47,6 @@ class AppValidate(unittest.TestCase):
             "application": {
                 "name": "killer_app",
                 "description": "add description",
-                "author": "add your name",
-                "email": "add@your.email",
                 "multi_round": False
             },
             "remote": {}
@@ -57,8 +55,6 @@ class AppValidate(unittest.TestCase):
             "application": {
                 "name": "remote_app",
                 "description": "add description",
-                "author": "add your name",
-                "email": "add@your.email",
                 "multi_round": False
             },
             "remote": {
@@ -421,8 +417,6 @@ class ApplicationValidate(AppValidate):
                 "application": {
                     "name": "test_application",
                     "description": "add description",
-                    "author": "add your name",
-                    "email": "add@your.email",
                     "multi_round": False
                 },
                 "remote": {}
@@ -488,8 +482,6 @@ class ApplicationValidate(AppValidate):
                 "application": {
                     "name": "new_app",
                     "description": "add description",
-                    "author": "add your name",
-                    "email": "add@your.email",
                     "multi_round": False
                 },
                 "remote": {}

--- a/src/tests/api/test_qne_client.py
+++ b/src/tests/api/test_qne_client.py
@@ -13,11 +13,11 @@ class TestQneFrontendClient(unittest.TestCase):
                                  {
                                      'id': 90, 'url': 'http://127.0.0.1:8000/applications/90/',
                                      'name': 'killer_app', 'slug': 'killer_app', 'date': '2022-03-07',
-                                     'description': 'add description', 'author': 'add your name',
-                                     'email': 'add@your.email', 'is_draft': False, 'is_public': True,
+                                     'description': 'add description',
+                                     'is_draft': False, 'is_public': True,
                                      'is_disabled': False,
                                      'owner': {
-                                         'id': 2, 'bio': '', 'avatar': None, 'slack_handle': '', 'nickname': 'user_2'
+                                         'id': 2, 'bio': '', 'avatar': None, 'slack_handle': '', 'username': 'user_2'
                                      },
                                      'number_of_successful_runs': 2
                                  },
@@ -26,7 +26,6 @@ class TestQneFrontendClient(unittest.TestCase):
                                      'name': 'QKD', 'slug': 'qkd', 'date': '2021-09-20',
                                      'description': 'QKD is a quantum key distribution scheme developed by '
                                                     'Charles Bennett and Gilles Brassard in 1984.',
-                                     'author': 'Axel Dahlberg', 'email': 'a.dahlberg@tudelft.nl',
                                      'is_draft': False, 'is_public': True, 'is_disabled': False,
                                      'owner': None, 'number_of_successful_runs': 1
                                  },
@@ -35,7 +34,6 @@ class TestQneFrontendClient(unittest.TestCase):
                                      'name': 'Blind computation', 'slug': 'blind-computation', 'date': '2022-01-13',
                                      'description': 'This example demonstrates the quantum blind '
                                                     'computation application.',
-                                     'author': 'Bart van der Vecht', 'email': 'B.vanderVecht@tudelft.nl',
                                      'is_draft': False, 'is_public': True, 'is_disabled': False, 'owner': None,
                                      'number_of_successful_runs': 1
                                  },
@@ -45,22 +43,21 @@ class TestQneFrontendClient(unittest.TestCase):
                                      'slug': 'distributed-cnot', 'date': '2021-09-20',
                                      'description': 'Performs a CNOT operation distributed over two nodes: Controller '
                                                     'and Target. Controller owns the control qubit and Target the '
-                                                    'target qubit.', 'author': 'Axel Dahlberg',
-                                     'email': 'a.dahlberg@tudelft.nl', 'is_draft': False, 'is_public': True,
+                                                    'target qubit.',
+                                     'is_draft': False, 'is_public': True,
                                      'is_disabled': False,
                                      'owner': {
                                          'id': 1, 'bio': 'This is my bio', 'avatar': None,
-                                         'slack_handle': 'This is my slack_handle', 'nickname': 'user_1'
+                                         'slack_handle': 'This is my slack_handle', 'username': 'user_1'
                                      },
                                      'number_of_successful_runs': 0
                                  },
                                  {
                                      'id': 92, 'url': 'http://127.0.0.1:8000/applications/92/', 'name': 'local_app',
                                      'slug': 'local_app', 'date': '2022-07-18', 'description': 'add description',
-                                     'author': 'add your name', 'email': 'add@your.email', 'is_draft': False,
-                                     'is_public': True, 'is_disabled': False,
+                                     'is_draft': False, 'is_public': True, 'is_disabled': False,
                                      'owner': {
-                                         'id': 2, 'bio': '', 'avatar': None, 'slack_handle': '', 'nickname': 'user_2'
+                                         'id': 2, 'bio': '', 'avatar': None, 'slack_handle': '', 'username': 'user_2'
                                      },
                                      'number_of_successful_runs': 0
                                  }
@@ -106,8 +103,6 @@ class TestQneFrontendClient(unittest.TestCase):
             "slug": "state-teleportation",
             "date": "2021-11-17",
             "description": "Quantum teleportation is a process in which quantum information (e.g. the exact state of an atom or photon) can be transmitted (exactly, in principle) from one location to another, with the help of classical communication and previously shared quantum entanglement between the sending and receiving location.",
-            "author": "Axel Dahlberg",
-            "email": "a.dahlberg@tudelft.nl",
             "is_draft": False,
             "is_public": True,
             "is_disabled": False
@@ -119,8 +114,6 @@ class TestQneFrontendClient(unittest.TestCase):
             "slug": "distributed-cnot",
             "date": "2021-11-17",
             "description": "Performs a CNOT operation distributed over two nodes: Controller and Target. Controller owns the control qubit and Target the target qubit.",
-            "author": "Axel Dahlberg",
-            "email": "a.dahlberg@tudelft.nl",
             "is_draft": False,
             "is_public": True,
             "is_disabled": False
@@ -132,8 +125,6 @@ class TestQneFrontendClient(unittest.TestCase):
             "slug": "qkd",
             "date": "2021-11-17",
             "description": "QKD is a quantum key distribution scheme developed by Charles Bennett and Gilles Brassard in 1984.",
-            "author": "Axel Dahlberg",
-            "email": "a.dahlberg@tudelft.nl",
             "is_draft": False,
             "is_public": True,
             "is_disabled": False

--- a/src/tests/api/test_remote_api.py
+++ b/src/tests/api/test_remote_api.py
@@ -12,7 +12,7 @@ class TestRemoteApi(unittest.TestCase):
         self.app_path = Path("path/to/application")
         self.base_uri = 'base_uri.com'
         self.host = 'http://unittest_server/'
-        self.username = 'username'
+        self.email = 'test@email.com'
         self.password = 'password'
         self.token = 'token'
         self.application_data = {
@@ -141,8 +141,8 @@ class TestRemoteApi(unittest.TestCase):
 
 class TestRemoteApiAuthentication(TestRemoteApi):
     def test_login(self):
-        self.remote_api.login(self.username, self.password, self.host)
-        self.remote_api.auth_manager.login.assert_called_once_with(self.username, self.password, self.host)
+        self.remote_api.login(self.email, self.password, self.host)
+        self.remote_api.auth_manager.login.assert_called_once_with(self.email, self.password, self.host)
 
     def test_logout(self):
         self.remote_api._RemoteApi__qne_client.is_logged_in.return_value = False

--- a/src/tests/api/test_remote_api.py
+++ b/src/tests/api/test_remote_api.py
@@ -19,8 +19,6 @@ class TestRemoteApi(unittest.TestCase):
             "application": {
                 "name": "test_app",
                 "description": "test_app description",
-                "author": "my name",
-                "email": "me@my.email",
                 "multi_round": False
             },
             "remote": {}
@@ -73,8 +71,6 @@ class TestRemoteApi(unittest.TestCase):
         self.application_data_uploaded = {
             'application': {'name': 'test_app',
                             'description': 'test_app description',
-                            'author': 'my name',
-                            'email': 'me@my.email',
                             'multi_round': False
                             },
             'remote': {'application': f'{self.host}application/42',
@@ -96,9 +92,7 @@ class TestRemoteApi(unittest.TestCase):
             "url": f"{self.host}application/42",
             "slug": "application_slug",
             "name": self.application_data["application"]["name"],
-            "description": self.application_data["application"]["description"],
-            "author": self.application_data["application"]["author"],
-            "email": self.application_data["application"]["email"]
+            "description": self.application_data["application"]["description"]
         }
 
         self.app_version = {
@@ -141,8 +135,9 @@ class TestRemoteApi(unittest.TestCase):
 
 class TestRemoteApiAuthentication(TestRemoteApi):
     def test_login(self):
-        self.remote_api.login(self.email, self.password, self.host)
-        self.remote_api.auth_manager.login.assert_called_once_with(self.email, self.password, self.host)
+        self.remote_api.login(self.email, self.password, self.host, use_username=False)
+        self.remote_api.auth_manager.login.assert_called_once_with(self.email, self.password,
+                                                                   self.host, False)
 
     def test_logout(self):
         self.remote_api._RemoteApi__qne_client.is_logged_in.return_value = False
@@ -192,8 +187,6 @@ class TestRemoteApiApplication(TestRemoteApi):
                 "application": {
                     "name": "new_app",
                     "description": "add description",
-                    "author": "add your name",
-                    "email": "add@your.email",
                     "multi_round": False
                 },
                 "remote": {}
@@ -262,9 +255,7 @@ class TestRemoteApiApplication(TestRemoteApi):
             "url": f"{self.host}application/42",
             "slug": "application_slug",
             "name": application_data["application"]["name"],
-            "description": application_data["application"]["description"],
-            "author": application_data["application"]["author"],
-            "email": application_data["application"]["email"]
+            "description": application_data["application"]["description"]
         }
 
         self.remote_api._RemoteApi__qne_client.create_application.return_value = application
@@ -414,9 +405,7 @@ class TestRemoteApiApplication(TestRemoteApi):
             "url": application_data["remote"]["application"],
             "slug": application_data["remote"]["slug"],
             "name": application_data["application"]["name"],
-            "description": application_data["application"]["description"],
-            "author": application_data["application"]["author"],
-            "email": application_data["application"]["email"]
+            "description": application_data["application"]["description"]
         }
         app_version = {
             "id": 42,

--- a/src/tests/managers/test_auth_manager.py
+++ b/src/tests/managers/test_auth_manager.py
@@ -35,7 +35,7 @@ class TestAuthManager(unittest.TestCase):
                                        {'email': self.email, 'password': self.password,
                                         'host': self.host, 'use_username': self.use_username})
             expected = {f"{self.host}": {"token": 'token', "email": self.email,
-                                         "password": self.password, 'use_username': '1' if self.use_username else '0'}}
+                                         "password": self.password, 'use_username': self.use_username}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected)
             set_active_host_mock.assert_called_once_with(self.host)
 
@@ -158,7 +158,7 @@ class TestAuthManager(unittest.TestCase):
             expected_auth_config = {f"{active_host}": {"token": 'token',
                                                        "email": self.email,
                                                        "password": self.password,
-                                                       'use_username': '1' if self.use_username else '0'}}
+                                                       'use_username': self.use_username}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected_auth_config)
 
     def test_get_password(self):
@@ -214,7 +214,7 @@ class TestAuthManager(unittest.TestCase):
 
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
-            use_username_to_get = '1'
+            use_username_to_get = True
             auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password,
                                             "use_username": use_username_to_get}}
             read_json_mock.return_value = auth_config
@@ -222,7 +222,7 @@ class TestAuthManager(unittest.TestCase):
             use_username = auth_manager.get_use_username(self.host)
             self.assertEqual(use_username, True)
 
-            use_username_to_get = '0'
+            use_username_to_get = False
             auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password,
                                             "use_username": use_username_to_get}}
             read_json_mock.return_value = auth_config

--- a/src/tests/managers/test_auth_manager.py
+++ b/src/tests/managers/test_auth_manager.py
@@ -15,6 +15,7 @@ class TestAuthManager(unittest.TestCase):
         self.host = 'http://unittest_server/'
         self.email = 'test@email.com'
         self.password = 'test_password'
+        self.use_username = False
 
     def test_login(self):
         with patch("adk.managers.auth_manager.Path.is_file", return_value=True), \
@@ -29,10 +30,12 @@ class TestAuthManager(unittest.TestCase):
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
 
             fetch_token_mock.return_value = 'token'
-            auth_manager.login(email=self.email, password=self.password, host=self.host)
+            auth_manager.login(email=self.email, password=self.password, host=self.host, use_username=self.use_username)
             fetch_token_mock.assert_called_once_with(self.login_function,
-                                       {'email': self.email, 'password': self.password, 'host': self.host})
-            expected = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password}}
+                                       {'email': self.email, 'password': self.password,
+                                        'host': self.host, 'use_username': self.use_username})
+            expected = {f"{self.host}": {"token": 'token', "email": self.email,
+                                         "password": self.password, 'use_username': '1' if self.use_username else '0'}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected)
             set_active_host_mock.assert_called_once_with(self.host)
 
@@ -49,9 +52,9 @@ class TestAuthManager(unittest.TestCase):
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
 
             fetch_token_mock.return_value = 'token'
-            auth_manager.login(email=None, password=None, host=None)
+            auth_manager.login(email=None, password=None, host=None, use_username=None)
             fetch_token_mock.assert_called_once_with(self.fallback_function, {'host': QNE_URL})
-            expected = {f"{QNE_URL}": {"token": 'token', "email": None, "password": None}}
+            expected = {f"{QNE_URL}": {"token": 'token', "email": None, "password": None, "use_username": None}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected)
             set_active_host_mock.assert_called_once_with(QNE_URL)
 
@@ -148,11 +151,14 @@ class TestAuthManager(unittest.TestCase):
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             fetch_token_mock.return_value = 'token'
             new_active_host = 'new_active_host'
-            auth_manager.login(email=self.email, password=self.password, host=new_active_host)
+            auth_manager.login(email=self.email, password=self.password,
+                               host=new_active_host, use_username=self.use_username)
             active_host = auth_manager.get_active_host()
             self.assertEqual(active_host, new_active_host)
-            expected_auth_config = {f"{active_host}": {"token": 'token', "email": self.email,
-                                                       "password": self.password}}
+            expected_auth_config = {f"{active_host}": {"token": 'token',
+                                                       "email": self.email,
+                                                       "password": self.password,
+                                                       'use_username': '1' if self.use_username else '0'}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected_auth_config)
 
     def test_get_password(self):
@@ -165,7 +171,8 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             password_to_get = 'password_to_get'
-            auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": password_to_get}}
+            auth_config = {f"{self.host}": {"token": 'token', "email": self.email,
+                                            "password": password_to_get, "use_username": self.use_username}}
             read_json_mock.return_value = auth_config
 
             password = auth_manager.get_password(self.host)
@@ -186,7 +193,8 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             email_to_get = 'get@email.com'
-            auth_config = {f"{self.host}": {"token": 'token', "email": email_to_get, "password": self.password}}
+            auth_config = {f"{self.host}": {"token": 'token', "email": email_to_get,
+                                            "password": self.password, "use_username": self.use_username}}
             read_json_mock.return_value = auth_config
 
             email = auth_manager.get_email(self.host)
@@ -196,3 +204,33 @@ class TestAuthManager(unittest.TestCase):
 
             email = auth_manager.get_email(self.host)
             self.assertIsNone(email)
+
+    def test_get_use_username(self):
+        with patch("adk.managers.auth_manager.Path.is_file", return_value=True), \
+             patch("adk.managers.auth_manager.os.path.isdir", return_value=True), \
+             patch("adk.managers.auth_manager.Path.mkdir"), \
+             patch.object(AuthManager, "_AuthManager__read_active_host", return_value='host'), \
+             patch("adk.managers.auth_manager.read_json_file") as read_json_mock:
+
+            auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
+                                       fallback_function=self.fallback_function, logout_function=self.logout_function)
+            use_username_to_get = '1'
+            auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password,
+                                            "use_username": use_username_to_get}}
+            read_json_mock.return_value = auth_config
+
+            use_username = auth_manager.get_use_username(self.host)
+            self.assertEqual(use_username, True)
+
+            use_username_to_get = '0'
+            auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password,
+                                            "use_username": use_username_to_get}}
+            read_json_mock.return_value = auth_config
+
+            use_username = auth_manager.get_use_username(self.host)
+            self.assertEqual(use_username, False)
+
+            read_json_mock.return_value = {}
+
+            use_username = auth_manager.get_use_username(self.host)
+            self.assertIsNone(use_username)

--- a/src/tests/managers/test_auth_manager.py
+++ b/src/tests/managers/test_auth_manager.py
@@ -13,7 +13,7 @@ class TestAuthManager(unittest.TestCase):
         self.fallback_function = Mock()
         self.path = Path('path/to/application')
         self.host = 'http://unittest_server/'
-        self.username = 'test_username'
+        self.email = 'test@email.com'
         self.password = 'test_password'
 
     def test_login(self):
@@ -29,10 +29,10 @@ class TestAuthManager(unittest.TestCase):
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
 
             fetch_token_mock.return_value = 'token'
-            auth_manager.login(username=self.username, password=self.password, host=self.host)
+            auth_manager.login(email=self.email, password=self.password, host=self.host)
             fetch_token_mock.assert_called_once_with(self.login_function,
-                                       {'username': self.username, 'password': self.password, 'host': self.host})
-            expected = {f"{self.host}": {"token": 'token', "username": self.username, "password": self.password}}
+                                       {'email': self.email, 'password': self.password, 'host': self.host})
+            expected = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected)
             set_active_host_mock.assert_called_once_with(self.host)
 
@@ -49,9 +49,9 @@ class TestAuthManager(unittest.TestCase):
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
 
             fetch_token_mock.return_value = 'token'
-            auth_manager.login(username=None, password=None, host=None)
+            auth_manager.login(email=None, password=None, host=None)
             fetch_token_mock.assert_called_once_with(self.fallback_function, {'host': QNE_URL})
-            expected = {f"{QNE_URL}": {"token": 'token', "username": None, "password": None}}
+            expected = {f"{QNE_URL}": {"token": 'token', "email": None, "password": None}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected)
             set_active_host_mock.assert_called_once_with(QNE_URL)
 
@@ -68,7 +68,7 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             get_active_host_mock.return_value = self.host
-            auth_config = {f"{self.host}": {"token": 'token', "username": self.username, "password": self.password}}
+            auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password}}
             read_json_mock.return_value = auth_config
             auth_manager.logout(None)
             self.logout_function.assert_called_once_with(self.host)
@@ -85,7 +85,7 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             token_to_load = 'token_to_load'
-            auth_config = {f"{self.host}": {"token": token_to_load, "username": self.username,
+            auth_config = {f"{self.host}": {"token": token_to_load, "email": self.email,
                                             "password": self.password}}
             read_json_mock.return_value = auth_config
 
@@ -108,12 +108,12 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             token_to_set = 'token_to_set'
-            auth_config = {f"{self.host}": {"token": 'token', "username": self.username, "password": self.password}}
+            auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": self.password}}
             read_json_mock.return_value = auth_config
 
             auth_manager.set_token(self.host, token_to_set)
 
-            expected_auth_config = {f"{self.host}": {"token": token_to_set, "username": self.username,
+            expected_auth_config = {f"{self.host}": {"token": token_to_set, "email": self.email,
                                                      "password": self.password}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected_auth_config)
 
@@ -127,7 +127,7 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             token = 'token'
-            auth_config = {f"{self.host}": {"token": token, "username": self.username, "password": self.password}}
+            auth_config = {f"{self.host}": {"token": token, "email": self.email, "password": self.password}}
             read_json_mock.return_value = auth_config
 
             the_host = auth_manager.get_host_from_token(token)
@@ -148,10 +148,10 @@ class TestAuthManager(unittest.TestCase):
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             fetch_token_mock.return_value = 'token'
             new_active_host = 'new_active_host'
-            auth_manager.login(username=self.username, password=self.password, host=new_active_host)
+            auth_manager.login(email=self.email, password=self.password, host=new_active_host)
             active_host = auth_manager.get_active_host()
             self.assertEqual(active_host, new_active_host)
-            expected_auth_config = {f"{active_host}": {"token": 'token', "username": self.username,
+            expected_auth_config = {f"{active_host}": {"token": 'token', "email": self.email,
                                                        "password": self.password}}
             write_json_mock.assert_called_once_with(self.path / 'qnerc', expected_auth_config)
 
@@ -165,7 +165,7 @@ class TestAuthManager(unittest.TestCase):
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
             password_to_get = 'password_to_get'
-            auth_config = {f"{self.host}": {"token": 'token', "username": self.username, "password": password_to_get}}
+            auth_config = {f"{self.host}": {"token": 'token', "email": self.email, "password": password_to_get}}
             read_json_mock.return_value = auth_config
 
             password = auth_manager.get_password(self.host)
@@ -176,7 +176,7 @@ class TestAuthManager(unittest.TestCase):
             password = auth_manager.get_password(self.host)
             self.assertIsNone(password)
 
-    def test_get_username(self):
+    def test_get_email(self):
         with patch("adk.managers.auth_manager.Path.is_file", return_value=True), \
              patch("adk.managers.auth_manager.os.path.isdir", return_value=True), \
              patch("adk.managers.auth_manager.Path.mkdir"), \
@@ -185,14 +185,14 @@ class TestAuthManager(unittest.TestCase):
 
             auth_manager = AuthManager(config_dir=self.path, login_function=self.login_function,
                                        fallback_function=self.fallback_function, logout_function=self.logout_function)
-            username_to_get = 'username_to_get'
-            auth_config = {f"{self.host}": {"token": 'token', "username": username_to_get, "password": self.password}}
+            email_to_get = 'get@email.com'
+            auth_config = {f"{self.host}": {"token": 'token', "email": email_to_get, "password": self.password}}
             read_json_mock.return_value = auth_config
 
-            username = auth_manager.get_username(self.host)
-            self.assertEqual(username, username_to_get)
+            email = auth_manager.get_email(self.host)
+            self.assertEqual(email, email_to_get)
 
             read_json_mock.return_value = {}
 
-            username = auth_manager.get_username(self.host)
-            self.assertIsNone(username)
+            email = auth_manager.get_email(self.host)
+            self.assertIsNone(email)

--- a/src/tests/managers/test_resource_manager.py
+++ b/src/tests/managers/test_resource_manager.py
@@ -11,8 +11,6 @@ class TestResourceManager(unittest.TestCase):
             "application": {
                 "name": "test_app",
                 "description": "test_app description",
-                "author": "my name",
-                "email": "me@my.email",
                 "multi_round": False
             },
             "remote": {

--- a/src/tests/test_command_list.py
+++ b/src/tests/test_command_list.py
@@ -35,8 +35,19 @@ class TestCommandList(unittest.TestCase):
             get_active_host_mock.return_value = 'test_host'
             login_output = self.runner.invoke(app, ['login', '--email=test@email.com',
                                                     '--password=test_password', 'test_host'])
-            login_mock.assert_called_once_with(host='test_host', email='test@email.com', password='test_password')
+            login_mock.assert_called_once_with(host='test_host', email='test@email.com',
+                                               password='test_password', use_username=False)
             self.assertIn("Log in to 'test_host' as user 'test@email.com' succeeded", login_output.stdout)
+
+    def test_login_email_as_username(self):
+        with patch.object(CommandProcessor, "login") as login_mock, \
+             patch.object(RemoteApi, 'get_active_host') as get_active_host_mock:
+
+            get_active_host_mock.return_value = 'test_host'
+            login_output = self.runner.invoke(app, ['login', '--email=test@email.com',
+                                                    '--password=test_password', '--username', 'test_host'])
+            login_mock.assert_called_once_with(host='test_host', email='test@email.com',
+                                               password='test_password', use_username=True)
 
     def test_logout(self):
         with patch.object(CommandProcessor, "logout") as logout_mock:

--- a/src/tests/test_command_list.py
+++ b/src/tests/test_command_list.py
@@ -33,10 +33,10 @@ class TestCommandList(unittest.TestCase):
              patch.object(RemoteApi, 'get_active_host') as get_active_host_mock:
 
             get_active_host_mock.return_value = 'test_host'
-            login_output = self.runner.invoke(app, ['login', '--username=test_username',
+            login_output = self.runner.invoke(app, ['login', '--email=test@email.com',
                                                     '--password=test_password', 'test_host'])
-            login_mock.assert_called_once_with(host='test_host', username='test_username', password='test_password')
-            self.assertIn("Log in to 'test_host' as user 'test_username' succeeded", login_output.stdout)
+            login_mock.assert_called_once_with(host='test_host', email='test@email.com', password='test_password')
+            self.assertIn("Log in to 'test_host' as user 'test@email.com' succeeded", login_output.stdout)
 
     def test_logout(self):
         with patch.object(CommandProcessor, "logout") as logout_mock:

--- a/src/tests/test_command_processor.py
+++ b/src/tests/test_command_processor.py
@@ -16,7 +16,7 @@ class TestCommandProcessor(unittest.TestCase):
         self.remote_api = MagicMock(config_manager=self.config_manager)
         self.processor = CommandProcessor(local_api=self.local_api, remote_api=self.remote_api)
         self.host = 'qutech.com'
-        self.username = 'test_username'
+        self.email = 'test@email.com'
         self.password = 'test_password'
         self.application = 'test_application'
         self.experiment = 'test_experiment'
@@ -27,8 +27,8 @@ class TestCommandProcessor(unittest.TestCase):
         self.error_dict = {"error": [], "warning": [], "info": []}
 
     def test_login(self):
-        self.processor.login(host=self.host, username=self.username, password=self.password)
-        self.remote_api.login.assert_called_once_with(username=self.username, password=self.password, host=self.host)
+        self.processor.login(host=self.host, email=self.email, password=self.password)
+        self.remote_api.login.assert_called_once_with(email=self.email, password=self.password, host=self.host)
 
     def test_logout(self):
         self.processor.logout(host=self.host)

--- a/src/tests/test_command_processor.py
+++ b/src/tests/test_command_processor.py
@@ -18,6 +18,7 @@ class TestCommandProcessor(unittest.TestCase):
         self.host = 'qutech.com'
         self.email = 'test@email.com'
         self.password = 'test_password'
+        self.use_username = True
         self.application = 'test_application'
         self.experiment = 'test_experiment'
         self.roles = ['role1', 'role2']
@@ -27,8 +28,9 @@ class TestCommandProcessor(unittest.TestCase):
         self.error_dict = {"error": [], "warning": [], "info": []}
 
     def test_login(self):
-        self.processor.login(host=self.host, email=self.email, password=self.password)
-        self.remote_api.login.assert_called_once_with(email=self.email, password=self.password, host=self.host)
+        self.processor.login(host=self.host, email=self.email, password=self.password, use_username=self.use_username)
+        self.remote_api.login.assert_called_once_with(email=self.email, password=self.password,
+                                                      host=self.host, use_username=self.use_username)
 
     def test_logout(self):
         self.processor.logout(host=self.host)

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -6,7 +6,7 @@ import unittest
 from adk.exceptions import InvalidPathName, JsonFileNotFound, MalformedJsonFile
 from adk.utils import check_python_syntax, copy_files, move_files, get_dummy_application, get_function_arguments, \
     get_function_return_variables, get_py_dummy, read_json_file, reorder_data, write_json_file, write_file, \
-    validate_path_name
+    validate_path_name, get_default_manifest
 
 
 class TestUtils(unittest.TestCase):
@@ -78,7 +78,17 @@ class TestUtils(unittest.TestCase):
         get_dummy_application(self.roles)
 
     def test_get_py_dummy(self):
-        get_py_dummy()
+        py_dummy = get_py_dummy()
+        self.assertIn('def main(app_config=None, x=0, y=0):', py_dummy)
+        self.assertIn('if __name__ == "__main__":', py_dummy)
+
+    def test_get_default_manifest(self):
+        default_manifest = get_default_manifest('my_app')
+        self.assertDictEqual({"application": {"name": "my_app",
+                                              "description": "add description",
+                                              "multi_round": False},
+                              "remote": {}}, default_manifest)
+
 
     def test_validate_path_name(self):
         self.assertRaises(InvalidPathName, validate_path_name, "object", self.invalid_name)


### PR DESCRIPTION
* built on QNEBE-611
* Backwards compatible login with --username flag to use email as username
* Tests added
* Documentation adjusted
* 2 application fields (author and email) are deleted
* nickname is changed to username in user record