### PR TITLE
[QNEBE-702] Remote structure stays empty after creation of app fails

### DIFF
--- a/src/adk/api/remote_api.py
+++ b/src/adk/api/remote_api.py
@@ -288,10 +288,10 @@ class RemoteApi:
 
         if application is None:
             try:
-                # create application data structure for remote
-                application_data["remote"] = get_default_remote_data()
                 # create Application
                 application = self.__create_application(application_data)
+                # create application data structure for remote
+                application_data["remote"] = get_default_remote_data()
 
             except Exception as e:
                 # rethrow exception

--- a/src/tests/api/test_remote_api.py
+++ b/src/tests/api/test_remote_api.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 from pathlib import Path
@@ -331,7 +332,7 @@ class TestRemoteApiApplication(TestRemoteApi):
         self.assertDictEqual(app_data_actual, self.application_data_uploaded)
 
     def test_upload_application_new_app_creation_fails(self):
-        application_data = self.application_data
+        application_data = copy.deepcopy(self.application_data)
         application_config = {"application": self.application_config, "network": self.network_config}
         application_source = ["application_source"]
         application_result = self.result
@@ -342,6 +343,7 @@ class TestRemoteApiApplication(TestRemoteApi):
                           application_config,
                           application_result,
                           application_source)
+        self.assertEqual(self.application_data, application_data)
 
     def test_upload_application_new_appversion_creation_fails(self):
         application_data = self.application_data


### PR DESCRIPTION
* Fill the remote structure with defaults only when the app creation was successful
* Adjusted unit test. Failed before the change, succeeds after the change.