### PR TITLE
[QNEBE-736] One role applications possible

### DIFF
--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -16,7 +16,7 @@ from adk.api.remote_api import RemoteApi
 from adk.command_processor import CommandProcessor
 from adk.decorators import catch_qne_adk_exceptions
 from adk.exceptions import (ApplicationAlreadyExists, ApplicationNotFound, ExperimentDirectoryNotValid,
-                            NotEnoughRoles, RolesNotUnique)
+                            RolesNotUnique)
 from adk.managers.config_manager import ConfigManager
 from adk.settings import Settings
 from adk.type_aliases import ErrorDictType
@@ -138,9 +138,6 @@ def applications_create(
     For example: qne application create application_name Alice Bob
     """
 
-    # Check roles
-    if len(roles) == 0:
-        raise NotEnoughRoles()
     # Lower case roles for testing for the same role
     lower_case_roles = [role.lower() for role in roles]
     if not all(lower_case_roles.count(role) == 1 for role in lower_case_roles):

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -139,7 +139,7 @@ def applications_create(
     """
 
     # Check roles
-    if len(roles) <= 1:
+    if len(roles) == 0:
         raise NotEnoughRoles()
     # Lower case roles for testing for the same role
     lower_case_roles = [role.lower() for role in roles]

--- a/src/adk/exceptions.py
+++ b/src/adk/exceptions.py
@@ -188,13 +188,6 @@ class NoNetworkAvailable(QneAdkException):
         super().__init__("No network available which contains enough nodes for all the roles")
 
 
-class NotEnoughRoles(QneAdkException):
-    """Raised when no roles are given"""
-
-    def __init__(self) -> None:
-        super().__init__("The number of roles must be at least one")
-
-
 class NotLoggedIn(QneAdkException):
     """Raised when remote host api is called without being logged in"""
 

--- a/src/adk/exceptions.py
+++ b/src/adk/exceptions.py
@@ -189,10 +189,10 @@ class NoNetworkAvailable(QneAdkException):
 
 
 class NotEnoughRoles(QneAdkException):
-    """Raised when only one role is given"""
+    """Raised when no roles are given"""
 
     def __init__(self) -> None:
-        super().__init__("The number of roles must be higher than one")
+        super().__init__("The number of roles must be at least one")
 
 
 class NotLoggedIn(QneAdkException):

--- a/src/tests/test_command_list.py
+++ b/src/tests/test_command_list.py
@@ -128,9 +128,9 @@ class TestCommandList(unittest.TestCase):
              patch.object(ConfigManager, "application_exists") as application_exists_mock:
 
             application_exists_mock.return_value = False, ""
-            # Raise NotEnoughRoles when only one or less roles are given
-            application_create_output = self.runner.invoke(applications_app, ['create', 'test_application', 'role1'])
-            self.assertIn('The number of roles must be higher than one', application_create_output.stdout)
+            # Raise error when no roles are given
+            application_create_output = self.runner.invoke(applications_app, ['create', 'test_application'])
+            self.assertIn("Missing argument 'ROLES...'", application_create_output.stdout)
 
             # Raise RolesNotUnique when roles are duplicated
             application_create_output = self.runner.invoke(applications_app, ['create', 'test_application', 'role1',


### PR DESCRIPTION
* The check for one role applications is wrong. It is possible to have an app with one role.
* Deleted the exception. It is never raised and not needed anymore
* Unit test adjusted to get the error from typer in case of no roles