### PR TITLE
[QNEBE-728] Update jsonschema validator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,8 @@ setup(
     license="MIT",
     packages=find_packages(where="src", exclude=["*tests*"]),
     install_requires=["typer[all]", "netqasm==0.13.3", "pydantic>=2.1.1", "pydantic-settings",
-                      "tabulate", "jsonschema==4.17.3", "pyyaml", "typing-extensions", "apistar",
-                      "typesystem==0.2.4", "pyjwt"],
+                      "tabulate", "jsonschema>=4.19.0", "referencing", "pyyaml", "typing-extensions",
+                      "apistar", "typesystem==0.2.4", "pyjwt"],
     extras_require={
         "dev": ["pylint", "coverage>=4.5.1", "mypy", "pytest", "black", "isort", "types-tabulate", "types-PyYAML",
                 "types-requests"],

--- a/src/adk/schema/experiments/asset.json
+++ b/src/adk/schema/experiments/asset.json
@@ -15,12 +15,12 @@
       "readOnly": true
     },
     "network": {
-      "$ref": "file:../networks/network_asset.json"
+      "$ref": "file:/networks/network_asset.json"
     },
     "application": {
       "type": "array",
       "items": {
-        "$ref": "file:../networks/roletemplate.json"
+        "$ref": "file:/networks/roletemplate.json"
       }
     },
     "experiment": {

--- a/src/adk/schema/experiments/experiment.json
+++ b/src/adk/schema/experiments/experiment.json
@@ -75,7 +75,7 @@
       ]
     },
     "asset": {
-      "$ref": "file:asset.json"
+      "$ref": "file:/experiments/asset.json"
     },
     "experiment": {
       "type": "string",

--- a/src/adk/schema/networks/channel_asset.json
+++ b/src/adk/schema/networks/channel_asset.json
@@ -19,7 +19,7 @@
     "parameters": {
       "type": "array",
       "items": {
-        "$ref": "file:template.json"
+        "$ref": "file:/networks/template.json"
       }
     }
   },

--- a/src/adk/schema/networks/network_asset.json
+++ b/src/adk/schema/networks/network_asset.json
@@ -24,13 +24,13 @@
     "nodes": {
       "type": "array",
       "items": {
-        "$ref": "file:node_asset.json"
+        "$ref": "file:/networks/node_asset.json"
       }
     },
     "channels": {
       "type": "array",
       "items": {
-        "$ref": "file:channel_asset.json"
+        "$ref": "file:/networks/channel_asset.json"
       }
     }
   },

--- a/src/adk/schema/networks/node_asset.json
+++ b/src/adk/schema/networks/node_asset.json
@@ -27,13 +27,13 @@
     "node_parameters": {
       "type": "array",
       "items": {
-        "$ref": "file:template.json"
+        "$ref": "file:/networks/template.json"
       }
     },
     "qubits": {
       "type": "array",
       "items": {
-        "$ref": "file:qubit.json"
+        "$ref": "file:/networks/qubit.json"
       }
     }
   },

--- a/src/adk/schema/networks/qubit.json
+++ b/src/adk/schema/networks/qubit.json
@@ -11,7 +11,7 @@
     "qubit_parameters": {
       "type": "array",
       "items": {
-        "$ref": "file:template.json"
+        "$ref": "file:/networks/template.json"
       }
     }
   },

--- a/src/tests/test_validators.py
+++ b/src/tests/test_validators.py
@@ -71,23 +71,17 @@ class TestValidators(unittest.TestCase):
                           f"Extra data: line 1 column 1 (char 31)", error)
 
     def test_validate_json_schema(self):
-        with patch("adk.validators.read_json_file") as read_json_file_mock, \
-             patch("adk.validators.platform.system") as system_mock:
+        with patch("adk.validators.read_json_file") as read_json_file_mock:
 
             read_json_file_mock.side_effect = [self.json_file, self.schema_file]
 
             validate_json_schema(self.path, self.path)
             self.assertEqual(read_json_file_mock.call_count, 2)
-            system_mock.assert_called_once()
             read_json_file_mock.assert_called_with(self.path)
 
-            # If platform.system() equals windows
-            system_mock.reset_mock()
-            system_mock.return_value = "Windows"
             read_json_file_mock.reset_mock()
             read_json_file_mock.side_effect = [self.json_file, self.schema_file]
             validate_json_schema(self.path, self.path)
-            system_mock.assert_called_once()
             self.assertEqual(read_json_file_mock.call_count, 2)
             read_json_file_mock.assert_called_with(self.path)
 
@@ -101,13 +95,10 @@ class TestValidators(unittest.TestCase):
             }
 
             read_json_file_mock.reset_mock()
-            system_mock.reset_mock()
-            system_mock.return_value = "Windows"
             read_json_file_mock.side_effect = [wrong_json_file, self.schema_file]
             validate_json_schema(self.path, self.path)
             self.assertEqual(read_json_file_mock.call_count, 2)
             read_json_file_mock.assert_called_with(self.path)
-            system_mock.assert_called_once()
 
     def test_validate_json_file(self):
         with patch("adk.validators.read_json_file") as read_json_file_mock:


### PR DESCRIPTION
Replace deprecated RefResolver with jsonschema referencing implementation.

NOTE: Using `type: ignore` because jsonschema 4.19 type stubs are not available. see: https://github.com/python/typeshed/pull/10417