### PR TITLE
[QNEBE-682] CLI return code matches error output

### DIFF
--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -15,8 +15,8 @@ from adk.api.local_api import LocalApi
 from adk.api.remote_api import RemoteApi
 from adk.command_processor import CommandProcessor
 from adk.decorators import catch_qne_adk_exceptions
-from adk.exceptions import (ApplicationAlreadyExists, ApplicationNotFound, ExperimentDirectoryNotValid,
-                            RolesNotUnique)
+from adk.exceptions import (ApplicationAlreadyExists, ApplicationNotFound, ApplicationFailedValidation,
+    ExperimentDirectoryNotValid, ExperimentFailedValidation, ExperimentExecutionError, RolesNotUnique)
 from adk.managers.config_manager import ConfigManager
 from adk.settings import Settings
 from adk.type_aliases import ErrorDictType
@@ -90,14 +90,18 @@ def retrieve_application_name_and_path(application_name: Optional[str]) -> Tuple
     return application_path, application_name
 
 
-def show_validation_messages(validation_dict: ErrorDictType) -> None:
+def format_validation_messages(validation_dict: ErrorDictType) -> str:
     """
-    Show the error, warnings and info messages collected during validation.
+    Format the error, warnings and info messages collected during validation for printing to the terminal.
     """
+    message = ""
     for key in validation_dict:
         if validation_dict[key]:
             for item in validation_dict[key]:
-                typer.echo(f"{key.upper()}: {item}")
+                if message:
+                    message += "\n"
+                message += f"{key.capitalize()}: {item}"
+    return message
 
 
 @applications_app.command("init")
@@ -224,9 +228,9 @@ def applications_clone(
         validate_dict = processor.applications_validate(application_name=application_name,
                                                         application_path=application_path)
         if validate_dict["error"] or validate_dict["warning"]:
-            show_validation_messages(validate_dict)
-            typer.echo(f"Local application '{application_name}' is invalid. Application not cloned")
-            return
+            typer.echo("Local application cannot be cloned.")
+            validation_messages = format_validation_messages(validate_dict)
+            raise ApplicationFailedValidation(application_name, validation_messages)
 
     processor.applications_clone(application_name=application_name,
                                  local=local,
@@ -254,12 +258,12 @@ def applications_delete(
     deleted_completely = processor.applications_delete(application_name=application_name,
                                                        application_path=application_path)
     if deleted_completely:
-        typer.echo("Application deleted successfully")
+        typer.echo("Application deleted successfully.")
     else:
         if application_name is None:
-            typer.echo("Application files deleted")
+            typer.echo("Application files deleted.")
         else:
-            typer.echo("Application files deleted, directory not empty")
+            typer.echo("Application files deleted, directory not empty.")
 
 
 @applications_app.command("upload")
@@ -278,16 +282,18 @@ def applications_upload(
     application_path, application_name = retrieve_application_name_and_path(application_name=application_name)
     validate_dict = processor.applications_validate(application_name=application_name,
                                                     application_path=application_path)
+    validation_messages = format_validation_messages(validate_dict)
+
     if validate_dict["error"] or validate_dict["warning"]:
-        show_validation_messages(validate_dict)
-        typer.echo(f"Application '{application_name}' is invalid. Application not uploaded")
+        typer.echo("Application could not be uploaded.")
+        raise ApplicationFailedValidation(application_name, validation_messages)
+
+    uploaded_success = processor.applications_upload(application_name=application_name,
+                                                     application_path=application_path)
+    if uploaded_success:
+        typer.echo(f"Application '{application_name}' uploaded successfully.")
     else:
-        uploaded_success = processor.applications_upload(application_name=application_name,
-                                                         application_path=application_path)
-        if uploaded_success:
-            typer.echo(f"Application '{application_name}' uploaded successfully")
-        else:
-            typer.echo(f"Application '{application_name}' not uploaded")
+        typer.echo(f"Application '{application_name}' not uploaded.")
 
 
 @applications_app.command("publish")
@@ -306,15 +312,17 @@ def applications_publish(
     application_path, application_name = retrieve_application_name_and_path(application_name=application_name)
     validate_dict = processor.applications_validate(application_name=application_name,
                                                     application_path=application_path)
+    validation_messages = format_validation_messages(validate_dict)
+
     if validate_dict["error"] or validate_dict["warning"]:
-        show_validation_messages(validate_dict)
-        typer.echo(f"Application '{application_name}' is invalid. Application not published")
+        typer.echo("Application could not be published.")
+        raise ApplicationFailedValidation(application_name, validation_messages)
+
+    publish_success = processor.applications_publish(application_path=application_path)
+    if publish_success:
+        typer.echo(f"Application '{application_name}' published successfully.")
     else:
-        publish_success = processor.applications_publish(application_path=application_path)
-        if publish_success:
-            typer.echo(f"Application '{application_name}' published successfully")
-        else:
-            typer.echo(f"Application '{application_name}' not published")
+        typer.echo(f"Application '{application_name}' not published.")
 
 
 @applications_app.command("list")
@@ -376,15 +384,16 @@ def applications_validate(
     """
     application_path, application_name = retrieve_application_name_and_path(application_name=application_name)
 
-    typer.echo(f"Validate application '{application_name}'")
-    error_dict = processor.applications_validate(application_name=application_name, application_path=application_path)
+    validate_dict = processor.applications_validate(application_name=application_name,
+                                                    application_path=application_path)
+    validation_messages = format_validation_messages(validate_dict)
 
-    show_validation_messages(error_dict)
+    if validate_dict["error"] or validate_dict["warning"]:
+        raise ApplicationFailedValidation(application_name, validation_messages)
 
-    if error_dict["error"] or error_dict["warning"]:
-        typer.echo(f"Application '{application_name}' is invalid")
-    else:
-        typer.echo(f"Application '{application_name}' is valid")
+    typer.echo(f"Application '{application_name}' is valid.")
+    if validation_messages:
+        typer.echo(f"{validation_messages}")
 
 
 @experiments_app.command("create")
@@ -411,12 +420,13 @@ def experiments_create(
     validate_dict = processor.applications_validate(application_name=application_name,
                                                     application_path=application_path, local=local)
     if validate_dict["error"] or validate_dict["warning"]:
-        show_validation_messages(validate_dict)
-        typer.echo(f"Application '{application_name}' is invalid. Experiment not created.")
-    else:
-        processor.experiments_create(experiment_name=experiment_name, application_name=application_name,
-                                     network_name=network_name, local=local, path=cwd)
-        typer.echo(f"Experiment '{experiment_name}' created successfully in directory '{cwd}'")
+        typer.echo("Experiment was not created.")
+        validation_messages = format_validation_messages(validate_dict)
+        raise ExperimentFailedValidation(validation_messages)
+
+    processor.experiments_create(experiment_name=experiment_name, application_name=application_name,
+                                 network_name=network_name, local=local, path=cwd)
+    typer.echo(f"Experiment '{experiment_name}' created successfully in directory '{cwd}'")
 
 
 @experiments_app.command("list")
@@ -527,42 +537,42 @@ def experiments_run(
     validate_dict = processor.experiments_validate(experiment_path=experiment_path)
 
     if validate_dict["error"] or validate_dict["warning"]:
-        show_validation_messages(validate_dict)
-        typer.echo("Experiment is invalid. Please resolve the issues and then run the experiment.")
-    else:
-        local = local_api.is_experiment_local(experiment_path=experiment_path)
+        typer.echo("Experiment did not run.")
+        validation_messages = format_validation_messages(validate_dict)
+        raise ExperimentFailedValidation(validation_messages)
+
+    local = local_api.is_experiment_local(experiment_path=experiment_path)
+    if local:
+        block = True
+    if update:
         if local:
-            block = True
-        if update:
-            if local:
-                # When updating the application files in the experiment, first validate the app again
-                application_name = local_api.get_experiment_application(experiment_path)
-                application_path, application_name = retrieve_application_name_and_path(
-                    application_name=application_name)
+            # When updating the application files in the experiment, first validate the app again
+            application_name = local_api.get_experiment_application(experiment_path)
+            application_path, application_name = retrieve_application_name_and_path(
+                application_name=application_name)
 
-                validate_dict = processor.applications_validate(application_name=application_name,
-                                                                application_path=application_path, local=local)
-                if validate_dict["error"] or validate_dict["warning"]:
-                    show_validation_messages(validate_dict)
-                    typer.echo(f"Application '{application_name}' is invalid. Experiment cannot be updated.")
-                    return
-            else:
-                typer.echo("Update only valid for local experiment runs.")
-                return
-
-        if block:
-            typer.echo(f"Experiment is sent to the {'local' if local else 'remote'} server. "
-                       f"Please wait until the results are received...")
-        results = processor.experiments_run(experiment_path=experiment_path, block=block, update=update,
-                                            timeout=timeout)
-        if results is not None:
-            if results and "error" in results[0]["round_result"]:
-                typer.echo("Error encountered while running the experiment")
-                typer.echo(results[0]["round_result"]["error"])
-            else:
-                typer.echo("Experiment run successfully. Check the results using command 'experiment results'")
+            validate_dict = processor.applications_validate(application_name=application_name,
+                                                            application_path=application_path, local=local)
+            if validate_dict["error"] or validate_dict["warning"]:
+                typer.echo("Experiment cannot be updated.")
+                validation_messages = format_validation_messages(validate_dict)
+                raise ApplicationFailedValidation(application_name, validation_messages)
         else:
-            typer.echo("Experiment sent successfully to server. Check the results using command 'experiment results'")
+            typer.echo("Update only valid for local experiment runs.")
+            return
+
+    if block:
+        typer.echo(f"Experiment is sent to the {'local' if local else 'remote'} server. "
+                   f"Please wait until the results are received...")
+    results = processor.experiments_run(experiment_path=experiment_path, block=block, update=update,
+                                        timeout=timeout)
+    if results is not None:
+        if results and "error" in results[0]["round_result"]:
+            raise ExperimentExecutionError(results[0]["round_result"]["error"])
+
+        typer.echo("Experiment run successfully. Check the results using command 'experiment results'.")
+    else:
+        typer.echo("Experiment sent successfully to server. Check the results using command 'experiment results'.")
 
 
 @experiments_app.command("validate")
@@ -577,15 +587,16 @@ def experiments_validate(
     given, the current directory is taken as experiment directory.
     """
     experiment_path, experiment_name = retrieve_experiment_name_and_path(experiment_name=experiment_name)
-    typer.echo(f"Validate experiment '{experiment_name}'\n")
 
-    error_dict = processor.experiments_validate(experiment_path=experiment_path)
-    show_validation_messages(error_dict)
+    validate_dict = processor.experiments_validate(experiment_path=experiment_path)
+    validation_messages = format_validation_messages(validate_dict)
 
-    if error_dict["error"] or error_dict["warning"]:
-        typer.echo("Experiment is invalid")
-    else:
-        typer.echo("Experiment is valid")
+    if validate_dict["error"] or validate_dict["warning"]:
+        raise ExperimentFailedValidation(validation_messages)
+
+    typer.echo("Experiment is valid.")
+    if validation_messages:
+        typer.echo(f"{validation_messages}")
 
 
 @experiments_app.command("results")
@@ -610,7 +621,7 @@ def experiments_results(
             result_noun = "Results are" if all_results else "Result is"
             typer.echo(f"{result_noun} stored at location '{experiment_path / 'results' / 'processed.json'}'")
     else:
-        typer.echo("No results received from backend yet. Check again later using command 'experiment results'")
+        typer.echo("No results received from backend yet. Check again later using command 'experiment results'.")
 
 
 @networks_app.command("list")
@@ -665,6 +676,6 @@ def networks_update(
     """
     updated = processor.networks_update(overwrite=overwrite)
     if updated:
-        typer.echo("The local networks are updated")
+        typer.echo("The local networks are updated.")
     else:
-        typer.echo("The local networks are not updated completely")
+        typer.echo("The local networks are not updated completely.")

--- a/src/adk/command_list.py
+++ b/src/adk/command_list.py
@@ -228,7 +228,7 @@ def applications_clone(
         validate_dict = processor.applications_validate(application_name=application_name,
                                                         application_path=application_path)
         if validate_dict["error"] or validate_dict["warning"]:
-            typer.echo("Local application cannot be cloned.")
+            typer.echo("Local application was not cloned")
             validation_messages = format_validation_messages(validate_dict)
             raise ApplicationFailedValidation(application_name, validation_messages)
 
@@ -258,12 +258,12 @@ def applications_delete(
     deleted_completely = processor.applications_delete(application_name=application_name,
                                                        application_path=application_path)
     if deleted_completely:
-        typer.echo("Application deleted successfully.")
+        typer.echo("Application deleted successfully")
     else:
         if application_name is None:
-            typer.echo("Application files deleted.")
+            typer.echo("Application files deleted")
         else:
-            typer.echo("Application files deleted, directory not empty.")
+            typer.echo("Application files deleted, directory not empty")
 
 
 @applications_app.command("upload")
@@ -285,15 +285,15 @@ def applications_upload(
     validation_messages = format_validation_messages(validate_dict)
 
     if validate_dict["error"] or validate_dict["warning"]:
-        typer.echo("Application could not be uploaded.")
+        typer.echo("Application was not uploaded")
         raise ApplicationFailedValidation(application_name, validation_messages)
 
     uploaded_success = processor.applications_upload(application_name=application_name,
                                                      application_path=application_path)
     if uploaded_success:
-        typer.echo(f"Application '{application_name}' uploaded successfully.")
+        typer.echo(f"Application '{application_name}' uploaded successfully")
     else:
-        typer.echo(f"Application '{application_name}' not uploaded.")
+        typer.echo(f"Application '{application_name}' not uploaded")
 
 
 @applications_app.command("publish")
@@ -315,14 +315,14 @@ def applications_publish(
     validation_messages = format_validation_messages(validate_dict)
 
     if validate_dict["error"] or validate_dict["warning"]:
-        typer.echo("Application could not be published.")
+        typer.echo("Application was not published")
         raise ApplicationFailedValidation(application_name, validation_messages)
 
     publish_success = processor.applications_publish(application_path=application_path)
     if publish_success:
-        typer.echo(f"Application '{application_name}' published successfully.")
+        typer.echo(f"Application '{application_name}' published successfully")
     else:
-        typer.echo(f"Application '{application_name}' not published.")
+        typer.echo(f"Application '{application_name}' not published")
 
 
 @applications_app.command("list")
@@ -391,7 +391,7 @@ def applications_validate(
     if validate_dict["error"] or validate_dict["warning"]:
         raise ApplicationFailedValidation(application_name, validation_messages)
 
-    typer.echo(f"Application '{application_name}' is valid.")
+    typer.echo(f"Application '{application_name}' is valid")
     if validation_messages:
         typer.echo(f"{validation_messages}")
 
@@ -420,7 +420,7 @@ def experiments_create(
     validate_dict = processor.applications_validate(application_name=application_name,
                                                     application_path=application_path, local=local)
     if validate_dict["error"] or validate_dict["warning"]:
-        typer.echo("Experiment was not created.")
+        typer.echo("Experiment was not created")
         validation_messages = format_validation_messages(validate_dict)
         raise ExperimentFailedValidation(validation_messages)
 
@@ -537,7 +537,7 @@ def experiments_run(
     validate_dict = processor.experiments_validate(experiment_path=experiment_path)
 
     if validate_dict["error"] or validate_dict["warning"]:
-        typer.echo("Experiment did not run.")
+        typer.echo("Experiment did not run")
         validation_messages = format_validation_messages(validate_dict)
         raise ExperimentFailedValidation(validation_messages)
 
@@ -554,11 +554,11 @@ def experiments_run(
             validate_dict = processor.applications_validate(application_name=application_name,
                                                             application_path=application_path, local=local)
             if validate_dict["error"] or validate_dict["warning"]:
-                typer.echo("Experiment cannot be updated.")
+                typer.echo("Experiment cannot be updated")
                 validation_messages = format_validation_messages(validate_dict)
                 raise ApplicationFailedValidation(application_name, validation_messages)
         else:
-            typer.echo("Update only valid for local experiment runs.")
+            typer.echo("Update only valid for local experiment runs")
             return
 
     if block:
@@ -570,9 +570,9 @@ def experiments_run(
         if results and "error" in results[0]["round_result"]:
             raise ExperimentExecutionError(results[0]["round_result"]["error"])
 
-        typer.echo("Experiment run successfully. Check the results using command 'experiment results'.")
+        typer.echo("Experiment run successfully. Check the results using command 'experiment results'")
     else:
-        typer.echo("Experiment sent successfully to server. Check the results using command 'experiment results'.")
+        typer.echo("Experiment sent successfully to server. Check the results using command 'experiment results'")
 
 
 @experiments_app.command("validate")
@@ -594,7 +594,7 @@ def experiments_validate(
     if validate_dict["error"] or validate_dict["warning"]:
         raise ExperimentFailedValidation(validation_messages)
 
-    typer.echo("Experiment is valid.")
+    typer.echo("Experiment is valid")
     if validation_messages:
         typer.echo(f"{validation_messages}")
 
@@ -621,7 +621,7 @@ def experiments_results(
             result_noun = "Results are" if all_results else "Result is"
             typer.echo(f"{result_noun} stored at location '{experiment_path / 'results' / 'processed.json'}'")
     else:
-        typer.echo("No results received from backend yet. Check again later using command 'experiment results'.")
+        typer.echo("No results received from backend yet. Check again later using command 'experiment results'")
 
 
 @networks_app.command("list")
@@ -676,6 +676,6 @@ def networks_update(
     """
     updated = processor.networks_update(overwrite=overwrite)
     if updated:
-        typer.echo("The local networks are updated.")
+        typer.echo("The local networks are updated")
     else:
-        typer.echo("The local networks are not updated completely.")
+        typer.echo("The local networks are not updated completely")

--- a/src/adk/decorators.py
+++ b/src/adk/decorators.py
@@ -1,3 +1,4 @@
+import sys
 import functools
 import logging
 from typing import Any, Callable
@@ -14,11 +15,11 @@ def catch_qne_adk_exceptions(func: Callable[..., Any]) -> Any:
         try:
             func(*args, **kwargs)
         except QneAdkException as qne_adk_exception:
-            message = f"Error: {str(qne_adk_exception)}"
-            typer.echo(message)
+            typer.echo(f"Error: {str(qne_adk_exception)}")
+            sys.exit(1)
         except Exception as exception:
-            message = f"Unhandled exception: {repr(exception)}"
-            typer.echo(message)
+            typer.echo(f"Unhandled exception: {repr(exception)}")
+            sys.exit(13)
 
     return catch_exceptions
 

--- a/src/adk/exceptions.py
+++ b/src/adk/exceptions.py
@@ -62,6 +62,14 @@ class ApplicationValueError(QneAdkException):
         super().__init__(f"{message}")
 
 
+class ApplicationFailedValidation(QneAdkException):
+    """Raised when an application fails validation"""
+
+    def __init__(self, application_name: str, validation_messages: str) -> None:
+        super().__init__(f"Application '{application_name}' failed validation. Please resolve the following issues:\n"
+                         f"{validation_messages}")
+
+
 class AuthenticationError(QneAdkException):
     """Raised when authentication failed"""
 
@@ -130,6 +138,21 @@ class ExperimentValueError(QneAdkException):
 
     def __init__(self, message: str) -> None:
         super().__init__(f"{message}")
+
+
+class ExperimentFailedValidation(QneAdkException):
+    """Raised when an experiment fails validation"""
+
+    def __init__(self, validation_messages: str) -> None:
+        super().__init__(f"Experiment failed validation. Please resolve the following issues:\n"
+                         f"{validation_messages}")
+
+
+class ExperimentExecutionError(QneAdkException):
+    """Raised when an experiment encountered an error while running"""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(f"Experiment encountered an error while running:\n{message}")
 
 
 class InvalidPath(QneAdkException):

--- a/src/tests/test_command_list.py
+++ b/src/tests/test_command_list.py
@@ -308,10 +308,10 @@ class TestCommandList(unittest.TestCase):
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
             # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": [ "an_error" ], "warning": [], "info": []}
+            applications_validate_mock.return_value = {"error": ["an_error"], "warning": [], "info": []}
             application_clone_output = self.runner.invoke(applications_app,
                                                           ['clone', self.application, 'new_app'])
-            self.assertIn(f"Local application cannot be cloned",
+            self.assertIn(f"Local application was not cloned",
                           application_clone_output.stdout)
             self.assertIn(f"Application '{self.application}' failed validation.",
                           application_clone_output.stdout)
@@ -421,7 +421,7 @@ class TestCommandList(unittest.TestCase):
             # When application is valid with item in in 'info'
             retrieve_appname_and_path_mock.reset_mock()
             applications_validate_mock.reset_mock()
-            applications_validate_mock.return_value = {"error": [], "warning": [], "info": [ "info" ]}
+            applications_validate_mock.return_value = {"error": [], "warning": [], "info": ["info"]}
 
             application_validate_output = self.runner.invoke(applications_app, ['validate'])
             applications_validate_mock.assert_called_once_with(application_name=self.application,
@@ -444,7 +444,7 @@ class TestCommandList(unittest.TestCase):
              patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock:
 
             retrieve_appname_and_path_mock.return_value = self.path, self.application
-            applications_validate_mock.return_value = {"error": [ "error" ], "warning": [ "warning" ], "info": [ "info" ]}
+            applications_validate_mock.return_value = {"error": ["error"], "warning": ["warning"], "info": ["info"]}
 
             application_validate_output = self.runner.invoke(applications_app, ['validate'])
             applications_validate_mock.assert_called_once_with(application_name=self.application,
@@ -455,7 +455,7 @@ class TestCommandList(unittest.TestCase):
             # When only 'error' has items
             retrieve_appname_and_path_mock.reset_mock()
             applications_validate_mock.reset_mock()
-            applications_validate_mock.return_value = {"error": [ "error" ], "warning": [], "info": []}
+            applications_validate_mock.return_value = {"error": ["error"], "warning": [], "info": []}
 
             application_validate_output = self.runner.invoke(applications_app, ['validate'])
             applications_validate_mock.assert_called_once_with(application_name=self.application,
@@ -514,7 +514,7 @@ class TestCommandList(unittest.TestCase):
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
             format_validation_messages_mock.assert_called_once()
             application_upload_mock.assert_not_called()
-            self.assertIn(f"Application could not be uploaded.",
+            self.assertIn(f"Application was not uploaded",
                           application_upload_output.stdout)
             self.assertIn(f"Application '{self.application}' failed validation.",
                           application_upload_output.stdout)
@@ -533,7 +533,7 @@ class TestCommandList(unittest.TestCase):
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
             application_publish_mock.assert_called_once_with(application_path=self.path)
             self.assertEqual(application_publish_output.exit_code, 0)
-            self.assertIn(f"Application '{self.application}' published successfully.",
+            self.assertIn(f"Application '{self.application}' published successfully",
                           application_publish_output.stdout)
 
     def test_applications_publish_fails(self):
@@ -550,7 +550,7 @@ class TestCommandList(unittest.TestCase):
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
             application_publish_mock.assert_called_once_with(application_path=self.path)
             self.assertEqual(application_publish_output.exit_code, 0)
-            self.assertIn(f"Application '{self.application}' not published.",
+            self.assertIn(f"Application '{self.application}' not published",
                           application_publish_output.stdout)
 
     def test_applications_publish_validation_error(self):
@@ -568,7 +568,7 @@ class TestCommandList(unittest.TestCase):
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
             format_validation_messages_mock.assert_called_once()
             application_publish_mock.assert_not_called()
-            self.assertIn(f"Application could not be published.",
+            self.assertIn(f"Application was not published",
                           application_publish_output.stdout)
             self.assertIn(f"Application '{self.application}' failed validation.",
                           application_publish_output.stdout)
@@ -694,9 +694,9 @@ class TestCommandList(unittest.TestCase):
 
             retrieve_application_name_and_path_mock.assert_called_once_with(application_name="app_name")
             self.assertEqual(experiment_create_output.exit_code, 1)
-            self.assertIn("Experiment was not created.",
+            self.assertIn("Experiment was not created",
                           experiment_create_output.stdout)
-            self.assertIn("Experiment failed validation.",
+            self.assertIn("Experiment failed validation",
                           experiment_create_output.stdout)
             experiment_create_mock.assert_not_called()
 
@@ -741,26 +741,26 @@ class TestCommandList(unittest.TestCase):
              patch.object(CommandProcessor, 'experiments_validate') as experiments_validate_mock, \
              patch("adk.command_list.format_validation_messages") as format_validation_messages_mock:
 
-            experiments_validate_mock.return_value = {"error": [ "error" ], "warning": [ "warning" ], "info": [ "info" ]}
+            experiments_validate_mock.return_value = {"error": ["error"], "warning": ["warning"], "info": ["info"]}
             retrieve_experiment_name_and_path_mock.return_value = (self.path, self.experiment_name)
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
             format_validation_messages_mock.assert_called_once()
-            self.assertIn("Experiment failed validation.", experiment_validate_output.stdout)
+            self.assertIn("Experiment failed validation", experiment_validate_output.stdout)
 
             # When only 'error' has items
             experiments_validate_mock.reset_mock()
             retrieve_experiment_name_and_path_mock.reset_mock()
             format_validation_messages_mock.reset_mock()
-            experiments_validate_mock.return_value = {"error": [ "error" ], "warning": [], "info": []}
+            experiments_validate_mock.return_value = {"error": ["error"], "warning": [], "info": []}
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
             format_validation_messages_mock.assert_called_once()
-            self.assertIn("Experiment failed validation.", experiment_validate_output.stdout)
+            self.assertIn("Experiment failed validation", experiment_validate_output.stdout)
 
             # When application is valid (no items in error, warning and info)
             experiments_validate_mock.reset_mock()
@@ -771,18 +771,18 @@ class TestCommandList(unittest.TestCase):
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
-            self.assertIn("Experiment is valid.", experiment_validate_output.stdout)
+            self.assertIn("Experiment is valid", experiment_validate_output.stdout)
 
             # When application is valid with item in in 'info'
             experiments_validate_mock.reset_mock()
             retrieve_experiment_name_and_path_mock.reset_mock()
             format_validation_messages_mock.reset_mock()
-            experiments_validate_mock.return_value = {"error": [], "warning": [], "info": [ "info" ]}
+            experiments_validate_mock.return_value = {"error": [], "warning": [], "info": ["info"]}
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
-            self.assertIn("Experiment is valid.", experiment_validate_output.stdout)
+            self.assertIn("Experiment is valid", experiment_validate_output.stdout)
 
     def test_experiment_delete_no_experiment_dir(self):
         with patch.object(CommandProcessor, 'experiments_delete', return_value=True) as experiments_delete_mock, \
@@ -957,7 +957,7 @@ class TestCommandList(unittest.TestCase):
             exp_run_mock.assert_not_called()
             retrieve_expname_and_path_mock.assert_called_once()
             self.assertEqual(exp_run_output.exit_code, 0)
-            self.assertIn("Update only valid for local experiment runs.", exp_run_output.stdout)
+            self.assertIn("Update only valid for local experiment runs", exp_run_output.stdout)
 
             exp_run_mock.reset_mock()
             retrieve_expname_and_path_mock.reset_mock()
@@ -974,7 +974,7 @@ class TestCommandList(unittest.TestCase):
             retrieve_expname_and_path_mock.assert_called_once()
             retrieve_appname_and_path_mock.assert_called_once()
             self.assertEqual(exp_run_output.exit_code, 1)
-            self.assertIn(f"Experiment cannot be updated.", exp_run_output.stdout)
+            self.assertIn(f"Experiment cannot be updated", exp_run_output.stdout)
             self.assertIn(f"Application '{self.application}' failed validation.", exp_run_output.stdout)
 
     def test_experiment_results(self):

--- a/src/tests/test_command_list.py
+++ b/src/tests/test_command_list.py
@@ -194,8 +194,6 @@ class TestCommandList(unittest.TestCase):
 
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
-            # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": {}, "warning": {}, "info": {}}
             application_fetch_output = self.runner.invoke(applications_app,
                                                           ['fetch', self.application])
             mock_cwd.assert_called_once()
@@ -213,13 +211,11 @@ class TestCommandList(unittest.TestCase):
         with patch("adk.command_list.Path.cwd", return_value=self.path) as mock_cwd, \
              patch.object(ConfigManager, "application_exists") as application_exists_mock, \
              patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock, \
-             patch.object(CommandProcessor, 'applications_validate') as applications_validate_mock, \
              patch.object(CommandProcessor, 'applications_fetch') as application_fetch_mock:
 
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
             # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": {}, "warning": {}, "info": {}}
             application_fetch_output = self.runner.invoke(applications_app,
                                                           ['fetch', 'fetch*app'])
 
@@ -244,7 +240,7 @@ class TestCommandList(unittest.TestCase):
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
             # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": {}, "warning": {}, "info": {}}
+            applications_validate_mock.return_value = {"error": [], "warning": [], "info": []}
             application_clone_output = self.runner.invoke(applications_app,
                                                           ['clone', self.application, 'new_app'])
             mock_cwd.assert_called_once()
@@ -270,7 +266,7 @@ class TestCommandList(unittest.TestCase):
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
             # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": {}, "warning": {}, "info": {}}
+            applications_validate_mock.return_value = {"error": [], "warning": [], "info": []}
             application_clone_output = self.runner.invoke(applications_app,
                                                           ['clone', self.application, '--remote'])
             mock_cwd.assert_called_once()
@@ -295,7 +291,7 @@ class TestCommandList(unittest.TestCase):
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
             # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": {}, "warning": {}, "info": {}}
+            applications_validate_mock.return_value = {"error": [], "warning": [], "info": []}
             application_clone_output = self.runner.invoke(applications_app,
                                                           ['clone', self.application, 'new*app'])
 
@@ -312,10 +308,12 @@ class TestCommandList(unittest.TestCase):
             application_exists_mock.return_value = False, ""
             retrieve_appname_and_path_mock.return_value = self.path, self.application
             # When application is valid (no items in error, warning and info)
-            applications_validate_mock.return_value = {"error": {"an_error"}, "warning": {}, "info": {}}
+            applications_validate_mock.return_value = {"error": [ "an_error" ], "warning": [], "info": []}
             application_clone_output = self.runner.invoke(applications_app,
                                                           ['clone', self.application, 'new_app'])
-            self.assertIn(f"Local application '{self.application}' is invalid. Application not cloned",
+            self.assertIn(f"Local application cannot be cloned",
+                          application_clone_output.stdout)
+            self.assertIn(f"Application '{self.application}' failed validation.",
                           application_clone_output.stdout)
 
             application_clone_output = self.runner.invoke(applications_app,
@@ -423,7 +421,7 @@ class TestCommandList(unittest.TestCase):
             # When application is valid with item in in 'info'
             retrieve_appname_and_path_mock.reset_mock()
             applications_validate_mock.reset_mock()
-            applications_validate_mock.return_value = {"error": {}, "warning": {}, "info": {"info"}}
+            applications_validate_mock.return_value = {"error": [], "warning": [], "info": [ "info" ]}
 
             application_validate_output = self.runner.invoke(applications_app, ['validate'])
             applications_validate_mock.assert_called_once_with(application_name=self.application,
@@ -446,24 +444,24 @@ class TestCommandList(unittest.TestCase):
              patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock:
 
             retrieve_appname_and_path_mock.return_value = self.path, self.application
-            applications_validate_mock.return_value = {"error": {"error"}, "warning": {"warning"}, "info": {"info"}}
+            applications_validate_mock.return_value = {"error": [ "error" ], "warning": [ "warning" ], "info": [ "info" ]}
 
             application_validate_output = self.runner.invoke(applications_app, ['validate'])
             applications_validate_mock.assert_called_once_with(application_name=self.application,
                                                                application_path=self.path)
             retrieve_appname_and_path_mock.assert_called_once()
-            self.assertIn(f"Application '{self.application}' is invalid", application_validate_output.stdout)
+            self.assertIn(f"Application '{self.application}' failed validation.", application_validate_output.stdout)
 
             # When only 'error' has items
             retrieve_appname_and_path_mock.reset_mock()
             applications_validate_mock.reset_mock()
-            applications_validate_mock.return_value = {"error": {"error"}, "warning": {}, "info": {}}
+            applications_validate_mock.return_value = {"error": [ "error" ], "warning": [], "info": []}
 
             application_validate_output = self.runner.invoke(applications_app, ['validate'])
             applications_validate_mock.assert_called_once_with(application_name=self.application,
                                                                application_path=self.path)
             retrieve_appname_and_path_mock.assert_called_once()
-            self.assertIn(f"Application '{self.application}' is invalid", application_validate_output.stdout)
+            self.assertIn(f"Application '{self.application}' failed validation.", application_validate_output.stdout)
 
     def test_applications_upload_success(self):
         with patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock, \
@@ -504,19 +502,21 @@ class TestCommandList(unittest.TestCase):
     def test_applications_upload_validation_error(self):
         with patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock, \
              patch.object(CommandProcessor, 'applications_validate') as app_validate_mock, \
-             patch("adk.command_list.show_validation_messages") as show_validation_messages_mock, \
+             patch("adk.command_list.format_validation_messages") as format_validation_messages_mock, \
              patch.object(CommandProcessor, 'applications_upload') as application_upload_mock:
 
             retrieve_appname_and_path_mock.return_value = self.path, self.application
-            app_validate_mock.return_value = {"error": ['Error'], "warning": [], "info": []}
+            app_validate_mock.return_value = {"error": [ 'Error' ], "warning": [], "info": []}
             application_upload_mock.return_value = True
 
             application_upload_output = self.runner.invoke(applications_app,
                                                            ['upload', 'test_application'])
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
-            show_validation_messages_mock.assert_called_once()
+            format_validation_messages_mock.assert_called_once()
             application_upload_mock.assert_not_called()
-            self.assertIn(f"Application '{self.application}' is invalid. Application not uploaded",
+            self.assertIn(f"Application could not be uploaded.",
+                          application_upload_output.stdout)
+            self.assertIn(f"Application '{self.application}' failed validation.",
                           application_upload_output.stdout)
 
     def test_applications_publish_success(self):
@@ -533,7 +533,7 @@ class TestCommandList(unittest.TestCase):
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
             application_publish_mock.assert_called_once_with(application_path=self.path)
             self.assertEqual(application_publish_output.exit_code, 0)
-            self.assertIn(f"Application '{self.application}' published successfully",
+            self.assertIn(f"Application '{self.application}' published successfully.",
                           application_publish_output.stdout)
 
     def test_applications_publish_fails(self):
@@ -550,13 +550,13 @@ class TestCommandList(unittest.TestCase):
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
             application_publish_mock.assert_called_once_with(application_path=self.path)
             self.assertEqual(application_publish_output.exit_code, 0)
-            self.assertIn(f"Application '{self.application}' not published",
+            self.assertIn(f"Application '{self.application}' not published.",
                           application_publish_output.stdout)
 
     def test_applications_publish_validation_error(self):
         with patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock, \
              patch.object(CommandProcessor, 'applications_validate') as app_validate_mock, \
-             patch("adk.command_list.show_validation_messages") as show_validation_messages_mock, \
+             patch("adk.command_list.format_validation_messages") as format_validation_messages_mock, \
              patch.object(CommandProcessor, 'applications_publish') as application_publish_mock:
 
             retrieve_appname_and_path_mock.return_value = self.path, self.application
@@ -566,9 +566,11 @@ class TestCommandList(unittest.TestCase):
             application_publish_output = self.runner.invoke(applications_app,
                                                             ['publish', 'test_application'])
             self.assertEqual(retrieve_appname_and_path_mock.call_count, 1)
-            show_validation_messages_mock.assert_called_once()
+            format_validation_messages_mock.assert_called_once()
             application_publish_mock.assert_not_called()
-            self.assertIn(f"Application '{self.application}' is invalid. Application not published",
+            self.assertIn(f"Application could not be published.",
+                          application_publish_output.stdout)
+            self.assertIn(f"Application '{self.application}' failed validation.",
                           application_publish_output.stdout)
 
     def test_applications_list(self):
@@ -676,7 +678,7 @@ class TestCommandList(unittest.TestCase):
         with patch("adk.command_list.Path.cwd") as mock_cwd, \
              patch.object(CommandProcessor, 'experiments_create') as experiment_create_mock, \
              patch.object(CommandProcessor, 'applications_validate') as app_validate_mock, \
-             patch("adk.command_list.show_validation_messages") as show_validation_messages_mock, \
+             patch("adk.command_list.format_validation_messages") as format_validation_messages_mock, \
              patch("adk.command_list.validate_path_name") as mock_validate_path, \
              patch("adk.command_list.retrieve_application_name_and_path") as retrieve_application_name_and_path_mock:
 
@@ -688,11 +690,13 @@ class TestCommandList(unittest.TestCase):
             experiment_create_output = self.runner.invoke(experiments_app, ['create', 'test_exp', 'app_name',
                                                                             'network_1'])
             mock_validate_path.assert_called_once_with('Experiment', 'test_exp')
-            show_validation_messages_mock.assert_called_once()
+            format_validation_messages_mock.assert_called_once()
 
             retrieve_application_name_and_path_mock.assert_called_once_with(application_name="app_name")
-            self.assertEqual(experiment_create_output.exit_code, 0)
-            self.assertIn("Application 'app_name' is invalid. Experiment not created.",
+            self.assertEqual(experiment_create_output.exit_code, 1)
+            self.assertIn("Experiment was not created.",
+                          experiment_create_output.stdout)
+            self.assertIn("Experiment failed validation.",
                           experiment_create_output.stdout)
             experiment_create_mock.assert_not_called()
 
@@ -735,52 +739,50 @@ class TestCommandList(unittest.TestCase):
     def test_experiment_validate(self):
         with patch("adk.command_list.retrieve_experiment_name_and_path") as retrieve_experiment_name_and_path_mock, \
              patch.object(CommandProcessor, 'experiments_validate') as experiments_validate_mock, \
-             patch("adk.command_list.show_validation_messages") as show_validation_messages_mock:
+             patch("adk.command_list.format_validation_messages") as format_validation_messages_mock:
 
-            experiments_validate_mock.return_value = {"error": {"error"}, "warning": {"warning"}, "info": {"info"}}
+            experiments_validate_mock.return_value = {"error": [ "error" ], "warning": [ "warning" ], "info": [ "info" ]}
             retrieve_experiment_name_and_path_mock.return_value = (self.path, self.experiment_name)
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
-            show_validation_messages_mock.assert_called_once()
-            self.assertIn("Experiment is invalid", experiment_validate_output.stdout)
+            format_validation_messages_mock.assert_called_once()
+            self.assertIn("Experiment failed validation.", experiment_validate_output.stdout)
 
             # When only 'error' has items
             experiments_validate_mock.reset_mock()
             retrieve_experiment_name_and_path_mock.reset_mock()
-            show_validation_messages_mock.reset_mock()
-            experiments_validate_mock.return_value = {"error": {"error"}, "warning": {}, "info": {}}
+            format_validation_messages_mock.reset_mock()
+            experiments_validate_mock.return_value = {"error": [ "error" ], "warning": [], "info": []}
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
-            show_validation_messages_mock.assert_called_once()
-            self.assertIn("Experiment is invalid", experiment_validate_output.stdout)
+            format_validation_messages_mock.assert_called_once()
+            self.assertIn("Experiment failed validation.", experiment_validate_output.stdout)
 
             # When application is valid (no items in error, warning and info)
             experiments_validate_mock.reset_mock()
             retrieve_experiment_name_and_path_mock.reset_mock()
-            show_validation_messages_mock.reset_mock()
-            experiments_validate_mock.return_value = {"error": {}, "warning": {}, "info": {}}
+            format_validation_messages_mock.reset_mock()
+            experiments_validate_mock.return_value = {"error": [], "warning": [], "info": []}
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
-            show_validation_messages_mock.assert_called_once()
-            self.assertIn("Experiment is valid", experiment_validate_output.stdout)
+            self.assertIn("Experiment is valid.", experiment_validate_output.stdout)
 
             # When application is valid with item in in 'info'
             experiments_validate_mock.reset_mock()
             retrieve_experiment_name_and_path_mock.reset_mock()
-            show_validation_messages_mock.reset_mock()
-            experiments_validate_mock.return_value = {"error": {}, "warning": {}, "info": {"info"}}
+            format_validation_messages_mock.reset_mock()
+            experiments_validate_mock.return_value = {"error": [], "warning": [], "info": [ "info" ]}
 
             experiment_validate_output = self.runner.invoke(experiments_app, ['validate'])
             retrieve_experiment_name_and_path_mock.assert_called_once_with(experiment_name=None)
             experiments_validate_mock.assert_called_once_with(experiment_path=self.path)
-            show_validation_messages_mock.assert_called_once()
-            self.assertIn("Experiment is valid", experiment_validate_output.stdout)
+            self.assertIn("Experiment is valid.", experiment_validate_output.stdout)
 
     def test_experiment_delete_no_experiment_dir(self):
         with patch.object(CommandProcessor, 'experiments_delete', return_value=True) as experiments_delete_mock, \
@@ -881,7 +883,7 @@ class TestCommandList(unittest.TestCase):
         with patch.object(CommandProcessor, 'experiments_validate') as exp_validate_mock, \
              patch.object(CommandProcessor, 'experiments_run') as exp_run_mock, \
              patch.object(LocalApi, "is_experiment_local") as exp_local_mock, \
-             patch("adk.command_list.show_validation_messages") as show_validation_messages_mock, \
+             patch("adk.command_list.format_validation_messages") as format_validation_messages_mock, \
              patch("adk.command_list.retrieve_experiment_name_and_path") as retrieve_expname_and_path_mock:
 
             retrieve_expname_and_path_mock.return_value = self.path, None
@@ -889,13 +891,13 @@ class TestCommandList(unittest.TestCase):
             exp_validate_mock.return_value = {"error": ["Error occurred"], "warning": [], "info": []}
             exp_run_output = self.runner.invoke(experiments_app, ['run'])
 
-            show_validation_messages_mock.assert_called_once()
+            format_validation_messages_mock.assert_called_once()
             exp_local_mock.assert_not_called()
             exp_validate_mock.assert_called_once_with(experiment_path=self.path)
             retrieve_expname_and_path_mock.assert_called_once_with(experiment_name=None)
             exp_run_mock.assert_not_called()
-            self.assertEqual(exp_run_output.exit_code, 0)
-            self.assertIn("Experiment is invalid. Please resolve the issues and then run the experiment.",
+            self.assertEqual(exp_run_output.exit_code, 1)
+            self.assertIn("Experiment failed validation.",
                           exp_run_output.stdout)
 
             exp_validate_mock.return_value = {"error": [], "warning": [], "info": []}
@@ -906,8 +908,8 @@ class TestCommandList(unittest.TestCase):
             exp_run_output = self.runner.invoke(experiments_app, ['run', '--timeout=30'])
             exp_run_mock.assert_called_once_with(experiment_path=self.path, block=False, update=False, timeout=30)
             retrieve_expname_and_path_mock.assert_called_once()
-            self.assertEqual(exp_run_output.exit_code, 0)
-            self.assertIn("Error encountered while running the experiment",
+            self.assertEqual(exp_run_output.exit_code, 1)
+            self.assertIn("Experiment encountered an error while running:",
                              exp_run_output.stdout)
             self.assertIn("Just an error",
                           exp_run_output.stdout)
@@ -944,7 +946,7 @@ class TestCommandList(unittest.TestCase):
              patch.object(CommandProcessor, 'experiments_run') as exp_run_mock, \
              patch.object(LocalApi, "is_experiment_local") as exp_local_mock, \
              patch.object(LocalApi, "get_experiment_application") as exp_application_mock, \
-             patch("adk.command_list.show_validation_messages") as show_validation_messages_mock, \
+             patch("adk.command_list.format_validation_messages") as format_validation_messages_mock, \
              patch("adk.command_list.retrieve_application_name_and_path") as retrieve_appname_and_path_mock, \
              patch("adk.command_list.retrieve_experiment_name_and_path") as retrieve_expname_and_path_mock:
 
@@ -968,12 +970,12 @@ class TestCommandList(unittest.TestCase):
             exp_local_mock.return_value = True
             exp_run_output = self.runner.invoke(experiments_app, ['run', '--timeout=30', '--update'])
             exp_run_mock.assert_not_called()
-            show_validation_messages_mock.assert_called_once()
+            format_validation_messages_mock.assert_called_once()
             retrieve_expname_and_path_mock.assert_called_once()
             retrieve_appname_and_path_mock.assert_called_once()
-            self.assertEqual(exp_run_output.exit_code, 0)
-            self.assertIn(f"Application '{self.application}' is invalid. Experiment cannot be updated.",
-                          exp_run_output.stdout)
+            self.assertEqual(exp_run_output.exit_code, 1)
+            self.assertIn(f"Experiment cannot be updated.", exp_run_output.stdout)
+            self.assertIn(f"Application '{self.application}' failed validation.", exp_run_output.stdout)
 
     def test_experiment_results(self):
         with patch.object(CommandProcessor, 'experiments_results') as exp_results_mock, \


### PR DESCRIPTION
In order to return system status codes, this PR applies a refactor to the CLI error handling.

### Summary of changes:
`exceptions.py`:
- New exceptions added: `ApplicationFailedValidation`, `ExperimentFailedValidation`, `ExperimentExecutionError`.

`decorators.py`:
- Return status code 1 for predicted errors.
- Return status code 13 for unpredicted error.

`command_list.py`:
- Exceptions are raised for any type of explicit failure.
- `show_validation_messages` becomes `format_validation_messages`, the output of which is passed to the appropriate exception.

`test_command_list.py`:
- Test whether predictable status code 1 is returned.
- Update tests for changes in error message formatting.
- Fix shape of ErrorDict where it did not match it's type.